### PR TITLE
feat: updated for linear history with proper versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Test, build, and verify version sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Must match the `go` directive in go.mod.
+          go-version: "1.24"
+
+      # Fails the build if any hand-edited doc has drifted from the Version
+      # constant in src/version/version.go. Run `make sync-version` locally to
+      # regenerate, then commit the diff.
+      - name: Verify documentation version sync
+        run: make version-check
+
+      - name: Run tests
+        run: make test
+
+      - name: Build (smoke test)
+        run: go build -o /tmp/carrion ./src
+
+      - name: Verify baked-in version string
+        run: |
+          # --version should report the Version from version.go (no commit
+          # suffix when Commit is empty).
+          EXPECTED="$(awk -F'"' '/^var Version =/{print $2; exit}' src/version/version.go)"
+          GOT="$(/tmp/carrion --version)"
+          echo "$GOT"
+          echo "$GOT" | grep -q "v$EXPECTED"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,25 @@
 name: "Carrion Language Build & Release"
 
+# Triggered by pushing a semver tag like `v0.1.10`. You do not need to edit
+# `src/version/version.go` or any docs before tagging — this workflow does it:
+#
+#   1. Extract the version from the tag.
+#   2. Rewrite `src/version/version.go` with that version.
+#   3. Run `make sync-version` to propagate it to every tracked doc.
+#   4. Commit the bump back to `main`.
+#   5. Build release artifacts with the correct version baked in via ldflags.
+#   6. Create the GitHub release with all artifacts attached.
+#
+# The only thing you do to ship a release is push the tag.
+
 on:
   push:
     tags:
-      - 'v*'  # e.g. v1.0.0
+      - 'v*'
+
+permissions:
+  # Needed to push the version-bump commit back to main.
+  contents: write
 
 jobs:
   build-and-release:
@@ -15,60 +31,87 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Needed to access branch history
-          persist-credentials: true  # Required for subsequent pushes
+          fetch-depth: 0
+          # Required so the post-bump commit can be pushed back to main.
+          persist-credentials: true
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          # Must match the `go` directive in go.mod.
+          go-version: "1.24"
 
       - name: Extract version from tag
         id: version_info
         run: |
-          RAW_VERSION="${GITHUB_REF##*/}"    # e.g. "v1.0.0"
-          VERSION="${RAW_VERSION#v}"        # e.g. "1.0.0"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          RAW_VERSION="${GITHUB_REF##*/}"   # e.g. "v0.1.10"
+          VERSION="${RAW_VERSION#v}"        # e.g. "0.1.10"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "RAW_VERSION=$RAW_VERSION" >> "$GITHUB_ENV"
+          # Sanity check — reject tags that aren't major.minor.patch so we fail
+          # fast instead of silently corrupting version.go.
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Tag $RAW_VERSION is not a valid semver (expected vMAJOR.MINOR.PATCH)."
+            exit 1
+          fi
 
-      - name: Update README version
+      # Rewrite src/version/version.go to the tag's version, then run
+      # versionsync to propagate through every tracked doc file. This is the
+      # single automated step that replaces the old manual "bump version.go
+      # and readmes before tagging" workflow.
+      - name: Bump version.go and sync docs
         run: |
-          # Update version in README
-          sed -i "s/{{VERSION}}/$VERSION/g" docs/README.md
-          
-          # Configure Git
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          
-          # Commit changes
-          git add docs/README.md
-          git commit -m "📚 Update README to version $VERSION"
-          
-          # Push to main branch
-          git push origin HEAD:main
+          sed -i -E 's/(^var Version = ")[^"]+(")/\1'"$VERSION"'\2/' src/version/version.go
+          make sync-version
 
-      - name: Build Artifacts
+      # Run tests against the post-bump tree so we know the tagged version
+      # compiles and passes.
+      - name: Run tests
+        run: make test
+
+      # Commit the bump + any doc rewrites back to main so the repo reflects
+      # the just-released version. The tag itself still points at the
+      # pre-bump commit (which is harmless — release binaries use ldflags, and
+      # the Unreleased → Released section move happens on main going forward).
+      - name: Commit version bump to main
         run: |
-          make build-source
-          make build-linux
-          make build-windows
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "No changes to commit — version.go and docs were already at $VERSION."
+          else
+            git add src/version/version.go docs/
+            git commit -m "chore: bump to $VERSION (automated)"
+            git push origin HEAD:main
+          fi
+
+      - name: Build all release artifacts
+        # CARRION_CHANNEL=release is the Makefile default; set explicitly for
+        # clarity. Version comes from version.go (just bumped) via ldflags.
+        run: CARRION_CHANNEL=release make build-release
 
       - name: Docker login
-        run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        if: env.DOCKER_USERNAME != ''
+        run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
       - name: Docker build and push
+        if: env.DOCKER_USERNAME != ''
         run: |
-          make build USER_NAME=$DOCKER_USERNAME VERSION=${{ env.VERSION }}
-          make push USER_NAME=$DOCKER_USERNAME VERSION=${{ env.VERSION }}
+          make build USER_NAME="$DOCKER_USERNAME" VERSION="$VERSION"
+          make push USER_NAME="$DOCKER_USERNAME" VERSION="$VERSION"
 
       - name: Create Release and Upload Assets
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: "Carrion Release ${{ env.VERSION }}"
+          generate_release_notes: true
           files: |
             carrion-src.tar.gz
             carrion_linux_amd64.tar.gz
+            carrion_linux_arm64.tar.gz
+            carrion_darwin_amd64.tar.gz
+            carrion_darwin_arm64.tar.gz
             carrion_windows_amd64.zip

--- a/Changelog/README.md
+++ b/Changelog/README.md
@@ -1,5 +1,81 @@
 # Carrion Language Changelog
 
+## Unreleased
+
+*Target: 0.1.10. Tag `v0.1.10` triggers the release workflow, which bumps
+`src/version/version.go` + docs automatically and cuts the GitHub release.*
+
+### Self-Update (`carrion update`)
+
+- New `carrion update` subcommand updates the installed binary in place by fetching the latest GitHub release. Uses prebuilt release assets matching the host OS/arch when available (`carrion_linux_amd64.tar.gz`, `carrion_darwin_amd64.tar.gz`, `carrion_windows_amd64.zip`), and falls back to a source build at the release tag when no asset is present.
+- `carrion update --experimental` tracks `main`-branch HEAD: fetches the latest commit, clones the source, and rebuilds with the commit SHA baked in (requires `git` and a Go 1.24+ toolchain).
+- `carrion update --check` reports status without installing. `-y` / `--yes` skips the confirmation prompt.
+- Stable releases take precedence over experimental builds: if you're on an experimental build ahead of the latest stable tag, `carrion update` warns and refuses to silently demote you — you can re-run without `--experimental` to explicitly pin back.
+- **Location**: `src/update/`
+
+### Versioning
+
+- New `src/version` package provides build-time-injectable metadata (`Version`, `Commit`, `Channel`, `BuildDate`) consumed by `carrion --version`.
+- Version format:
+  - `v{major}.{minor}.{patch}` for tagged stable releases (e.g. `v0.1.10`).
+  - `v{major}.{minor}.{patch}-{short-sha}` for experimental builds (e.g. `v0.1.10-a1b2c3d`).
+- The Makefile (`build-linux`, `build-windows`) and `install/install.sh` now inject `-ldflags` so the installed binary reports exactly what it was built from. `CARRION_VERSION` is parsed from `src/version/version.go` as the single source of truth; bumping the version only needs to happen there.
+
+### Evaluator Performance
+
+#### Integer Interning
+- Small integers (-5 to 256) are now cached at package init via `object.NewInteger()`, eliminating per-operation heap allocation for the most common values. All evaluator and builtin sites that previously produced `&object.Integer{Value: ...}` now route through the cache.
+- **Location**: `src/object/object.go`
+
+#### Deferred Primitive Wrapping
+- Primitives (`Integer`, `Float`, `String`, `Boolean`, `Array`) no longer auto-wrap into grimoire `Instance` objects at literal or expression time. Wrapping is deferred to `evalDotExpression` and happens only when a method is actually accessed on the primitive (via the new `wrapPrimitiveForMethod` helper).
+- User-visible semantics are unchanged — `"hello".upper()` and `[1, 2, 3].length()` still work — but tight arithmetic and string loops now avoid repeated `Instance` allocation.
+- **Location**: `src/evaluator/evaluator.go`
+
+#### Native Array Methods
+- 15 `Array` grimoire methods (`set`, `get`, `append`, `pop`, `length`, `is_empty`, `first`, `last`, `clear`, `reverse`, `sort`, `contains`, `index_of`, `remove`, `slice`) now execute in Go via `nativeArrayMethod` instead of interpreting the Carrion stdlib implementations. Dispatch is wired into `evalGrimoireMethodCall`, `evalBoundMethodCall`, and `evalBoundMethodCallWithNamed`.
+- **Location**: `src/evaluator/evaluator.go`
+
+#### Infix Fast Path
+- `evalInfixExpression` now short-circuits to type-specific handlers when both operands are already raw `*Integer`, `*Boolean`, or `*String`, skipping `unwrapPrimitive` entirely in the common case.
+- Arithmetic helpers (`evalIntegerInfixExpression`, `evalStringInfixExpression`, float/compound/increment paths) return raw primitives instead of re-wrapping after every operation.
+
+#### Eval Hot-Loop Cleanup
+- Removed `defer func() { CurrentContext = oldContext }()` from `Eval` by splitting into `Eval` (context save/restore) and a new inner `evalNode` (dispatch). Eliminates per-node closure allocation.
+- `NewEnclosedEnvironment` pre-sizes its map to 4 entries to match typical method/closure frames (`self` + a few params).
+- **Location**: `src/evaluator/evaluator.go`, `src/object/environment.go`
+
+### Performance Numbers
+
+Measured on an Intel i5-10500H (Linux, Go 1.24) by running the new benchmark
+suite at the pre-improvements commit (`f5b487a`) and at this release, with
+`count=3` to smooth variance.
+
+| Benchmark          | Before           | After            | Δ time   | Δ allocs |
+| ------------------ | ---------------- | ---------------- | -------- | -------- |
+| IntegerLoop        | 7.13 ms / 40 K   | 2.21 ms / 19.8 K | **3.2×** | −50.6%   |
+| Arithmetic         | 8.10 ms / 50 K   | 2.62 ms / 24.6 K | **3.1×** | −50.8%   |
+| Fibonacci (fib 20) | 45.4 ms / 263 K  | 17.5 ms / 164 K  | **2.6×** | −37.5%   |
+| ArrayBuild         | 14.9 ms / 9.0 K  | 2.93 ms / 5.75 K | **~5×**  | −36.1%   |
+| StringConcat       | 1.42 ms / 8.0 K  | 0.58 ms / 4.75 K | **2.4×** | −40.7%   |
+
+Memory per operation drops sharply on the arithmetic benchmarks (85–87% less)
+because small integers now bypass the allocator entirely. Reproduce with
+`make bench` on `main` and on this branch.
+
+### Tooling
+
+- `make bench` — runs `go test -bench=. -benchmem -count=1 ./src/evaluator/`
+- `make test` — runs `go test ./src/...`
+- `make sync-version` — rewrite version references in docs from `src/version/version.go`
+- `make version-check` — CI-friendly check that fails if docs are out of sync
+- `make build-mac`, `make build-linux-arm64`, `make build-release` — new release artifact targets
+- New benchmark suite at `src/evaluator/evaluator_bench_test.go` covering integer loops, arithmetic, recursion (fibonacci), array building, and string concatenation.
+- New semver unit tests at `src/update/semver_test.go`.
+- New `cmd/versionsync` tool — single source of truth for the Carrion version is `src/version/version.go`; the tool rewrites matching patterns in documentation. Run `make sync-version` after bumping, or wire `make version-check` into CI to enforce drift-free docs.
+
+---
+
 ## Version 0.1.8
 
 ### Tooling Ecosystem & Testing Framework

--- a/Makefile
+++ b/Makefile
@@ -29,25 +29,68 @@ ifeq ($(OS),unsupported)
 	$(error Unsupported operating system: $(UNAME_S). Please set OS manually to one of: linux, mac, windows)
 endif
 
-.PHONY: build push run clean install uninstall build-source build-linux build-windows bifrost-update tidy
+# Carrion binary version metadata injected via -ldflags so the built binary can
+# report exactly what source it came from. CARRION_VERSION is parsed from the
+# single source of truth in src/version/version.go.
+# CARRION_CHANNEL defaults to "release" because Makefile targets produce
+# distributable artifacts (tarballs consumed by `carrion update`). Override
+# with `CARRION_CHANNEL=dev` for local throwaway builds.
+CARRION_VERSION := $(shell awk -F'"' '/^var Version =/{print $$2; exit}' src/version/version.go)
+CARRION_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
+CARRION_CHANNEL ?= release
+CARRION_BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
+CARRION_LDFLAGS := -X github.com/javanhut/TheCarrionLanguage/src/version.Version=$(CARRION_VERSION) \
+                   -X github.com/javanhut/TheCarrionLanguage/src/version.Commit=$(CARRION_COMMIT) \
+                   -X github.com/javanhut/TheCarrionLanguage/src/version.Channel=$(CARRION_CHANNEL) \
+                   -X github.com/javanhut/TheCarrionLanguage/src/version.BuildDate=$(CARRION_BUILD_DATE)
+
+.PHONY: build push run clean install uninstall build-source build-linux build-linux-arm64 build-windows build-mac build-mac-amd64 build-mac-arm64 build-release bifrost-update tidy bench test sync-version version-check
 
 # 1) Build a tarball of the uncompiled source
 build-source:
 	git archive --format=tar.gz -o carrion-src.tar.gz HEAD	
 
-# 2) Build the Linux binary + tarball
+# 2) Build the Linux binary + tarball (amd64)
 build-linux:
-	GOOS=linux GOARCH=amd64 go build -o carrion ./src
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(CARRION_LDFLAGS)" -o carrion ./src
 	cd cmd/sindri && GOOS=linux GOARCH=amd64 go build -o sindri .
 	cd cmd/mimir && GOOS=linux GOARCH=amd64 go build -o mimir .
 	tar -czf carrion_linux_amd64.tar.gz carrion cmd/sindri/sindri cmd/mimir/mimir
 
+# 2b) Linux arm64 variant (for Raspberry Pi, Graviton, arm64 CI runners)
+build-linux-arm64:
+	GOOS=linux GOARCH=arm64 go build -ldflags "$(CARRION_LDFLAGS)" -o carrion ./src
+	cd cmd/sindri && GOOS=linux GOARCH=arm64 go build -o sindri .
+	cd cmd/mimir && GOOS=linux GOARCH=arm64 go build -o mimir .
+	tar -czf carrion_linux_arm64.tar.gz carrion cmd/sindri/sindri cmd/mimir/mimir
+
 # 3) Build the Windows binary + zip
 build-windows:
-	GOOS=windows GOARCH=amd64 go build -o carrion.exe ./src
+	GOOS=windows GOARCH=amd64 go build -ldflags "$(CARRION_LDFLAGS)" -o carrion.exe ./src
 	cd cmd/sindri && GOOS=windows GOARCH=amd64 go build -o sindri.exe .
 	cd cmd/mimir && GOOS=windows GOARCH=amd64 go build -o mimir.exe .
 	zip carrion_windows_amd64.zip carrion.exe cmd/sindri/sindri.exe cmd/mimir/mimir.exe
+
+# 4) macOS tarballs (both Intel and Apple Silicon)
+build-mac: build-mac-amd64 build-mac-arm64
+
+build-mac-amd64:
+	GOOS=darwin GOARCH=amd64 go build -ldflags "$(CARRION_LDFLAGS)" -o carrion ./src
+	cd cmd/sindri && GOOS=darwin GOARCH=amd64 go build -o sindri .
+	cd cmd/mimir && GOOS=darwin GOARCH=amd64 go build -o mimir .
+	tar -czf carrion_darwin_amd64.tar.gz carrion cmd/sindri/sindri cmd/mimir/mimir
+
+build-mac-arm64:
+	GOOS=darwin GOARCH=arm64 go build -ldflags "$(CARRION_LDFLAGS)" -o carrion ./src
+	cd cmd/sindri && GOOS=darwin GOARCH=arm64 go build -o sindri .
+	cd cmd/mimir && GOOS=darwin GOARCH=arm64 go build -o mimir .
+	tar -czf carrion_darwin_arm64.tar.gz carrion cmd/sindri/sindri cmd/mimir/mimir
+
+# 4b) Convenience: build every release artifact in one shot
+build-release: build-source build-linux build-linux-arm64 build-windows build-mac
+	@echo "Release artifacts:"
+	@ls -1 carrion_*_*.tar.gz carrion_*_*.zip carrion-src.tar.gz 2>/dev/null || true
 
 # Existing Docker image build
 build:
@@ -100,6 +143,23 @@ bifrost-update:
 	@echo "Updating Bifrost submodule..."
 	@git submodule update --init --recursive
 	@git submodule update --remote
+
+bench:
+	@echo "Running evaluator benchmarks..."
+	go test -bench=. -benchmem -count=1 ./src/evaluator/
+
+test:
+	@echo "Running all tests..."
+	go test ./src/...
+
+# Keep version references in documentation aligned with the single source of
+# truth in src/version/version.go. Run sync-version to rewrite stale mentions;
+# run version-check in CI to fail the build when docs drift.
+sync-version:
+	@go run ./cmd/versionsync
+
+version-check:
+	@go run ./cmd/versionsync --check
 
 tidy:
 	@echo "Running go mod tidy on all modules..."

--- a/cmd/versionsync/main.go
+++ b/cmd/versionsync/main.go
@@ -1,0 +1,155 @@
+// versionsync keeps version references in documentation aligned with the
+// single source of truth in src/version/version.go. Run without flags to
+// rewrite stale references. Run with --check to exit non-zero if anything is
+// out of sync (intended for CI and pre-commit hooks).
+//
+// Invocation:
+//
+//	go run ./cmd/versionsync          # apply updates in place
+//	go run ./cmd/versionsync --check  # report without modifying
+//
+// Add a new file that should track the Carrion version by appending an entry
+// to the `rules` slice below — there's no YAML/config file intentionally, so
+// the set of synced files stays grep-able from Go source.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+const versionFile = "src/version/version.go"
+
+// rule describes one file and the set of regex→format replacements the tool
+// should apply whenever the version bumps. Exactly one verb (%s) is required
+// per replacement so we can substitute the parsed version string.
+type rule struct {
+	path     string
+	replace  []replacement
+}
+
+type replacement struct {
+	// re matches the substring to replace. Use capturing groups sparingly;
+	// the replacement format string receives only the semver, not captures.
+	re     *regexp.Regexp
+	format string // must contain exactly one %s for the version
+}
+
+func mustRe(pattern string) *regexp.Regexp {
+	return regexp.MustCompile(pattern)
+}
+
+// rules is the full set of doc locations kept in sync with the Version const.
+// Add entries here rather than sprinkling version mentions ad-hoc throughout
+// docs — if it isn't in this list, it won't stay current.
+var rules = []rule{
+	{
+		path: "docs/README.md",
+		replace: []replacement{
+			{mustRe(`Latest Version: \d+\.\d+\.\d+`), "Latest Version: %s"},
+			{mustRe(`img\.shields\.io/badge/version-\d+\.\d+\.\d+-blue`), "img.shields.io/badge/version-%s-blue"},
+			{mustRe(`badge/version-\d+\.\d+\.\d+\.svg`), "badge/version-%s.svg"},
+			{mustRe(`- Current Version: \d+\.\d+\.\d+`), "- Current Version: %s"},
+		},
+	},
+	{
+		path: "docs/DOCUMENTATION.md",
+		replace: []replacement{
+			{mustRe("Base semver \\(major\\.minor\\.patch\\), e\\.g\\. `\\d+\\.\\d+\\.\\d+`"), "Base semver (major.minor.patch), e.g. `%s`"},
+		},
+	},
+}
+
+// readVersion parses `var Version = "x.y.z"` from src/version/version.go.
+// Returns a descriptive error if the pattern is missing so a future rename of
+// the field fails loudly rather than silently writing blanks into the docs.
+func readVersion(root string) (string, error) {
+	path := filepath.Join(root, versionFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	re := regexp.MustCompile(`var\s+Version\s*=\s*"([^"]+)"`)
+	m := re.FindSubmatch(data)
+	if len(m) < 2 {
+		return "", fmt.Errorf("could not locate `var Version = \"...\"` in %s", path)
+	}
+	return string(m[1]), nil
+}
+
+// sync applies all rules and returns the list of files it changed. In check
+// mode it returns the list of files that *would* change without writing.
+func sync(root, version string, check bool) ([]string, error) {
+	var changed []string
+	for _, r := range rules {
+		full := filepath.Join(root, r.path)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", full, err)
+		}
+		orig := data
+		for _, rep := range r.replace {
+			repl := []byte(fmt.Sprintf(rep.format, version))
+			data = rep.re.ReplaceAll(data, repl)
+		}
+		if !bytes.Equal(orig, data) {
+			changed = append(changed, r.path)
+			if !check {
+				if err := os.WriteFile(full, data, 0o644); err != nil {
+					return nil, fmt.Errorf("write %s: %w", full, err)
+				}
+			}
+		}
+	}
+	return changed, nil
+}
+
+func main() {
+	check := flag.Bool("check", false, "Report files that would change; exit 1 if any. Do not write.")
+	rootFlag := flag.String("root", ".", "Repository root (defaults to current directory)")
+	flag.Parse()
+
+	root, err := filepath.Abs(*rootFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(2)
+	}
+
+	v, err := readVersion(root)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(2)
+	}
+
+	changed, err := sync(root, v, *check)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(2)
+	}
+
+	if *check {
+		if len(changed) > 0 {
+			fmt.Fprintln(os.Stderr, "Out of sync with version", v+":")
+			for _, f := range changed {
+				fmt.Fprintln(os.Stderr, "  -", f)
+			}
+			fmt.Fprintln(os.Stderr, "Run `make sync-version` (or `go run ./cmd/versionsync`) to fix.")
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, "Documentation is in sync with version", v+".")
+		return
+	}
+
+	if len(changed) == 0 {
+		fmt.Fprintln(os.Stderr, "No changes — docs already match version", v+".")
+		return
+	}
+	fmt.Fprintln(os.Stderr, "Synced to version", v+":")
+	for _, f := range changed {
+		fmt.Fprintln(os.Stderr, "  -", f)
+	}
+}

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -294,12 +294,24 @@ The Carrion Language is implemented in Go and follows a traditional interpreter 
 - `unpackTuple()` - Tuple destructuring
 - `unpackMap()` - Hash destructuring
 
-#### Primitive Wrapping (5 functions)
-- `wrapPrimitive()` - Wrap primitives in grimoire instances
+#### Primitive Wrapping (6 functions)
+
+Primitives (`Integer`, `Float`, `String`, `Boolean`, `Array`) stay raw through literal evaluation and arithmetic. Wrapping into grimoire `Instance` objects is deferred to the dot-access boundary (`evalDotExpression`) so that hot loops avoid per-operation allocation while `"hello".upper()` and `[1,2,3].length()` still work as expected.
+
+- `wrapPrimitive()` - Deferred no-op retained for call-site compatibility; returns the primitive unchanged
+- `wrapPrimitiveForMethod()` - Creates an `Instance` on demand from `evalDotExpression` when a method is accessed on a raw primitive (looks up grimoires from `stdlibEnv` first, then local env)
 - `unwrapPrimitive()` - Extract primitives from instances
 - `isPrimitiveLiteral()` - Type checking
 - `shouldWrapStringResult()` - Wrapping decision logic
 - `isBuiltinFunction()` - Builtin detection
+
+#### Native Method Dispatch (3 functions)
+
+Performance-critical `Array` methods execute in Go instead of interpreting their Carrion stdlib bodies. Dispatch is wired into all three method-call paths (`evalGrimoireMethodCall`, `evalBoundMethodCall`, `evalBoundMethodCallWithNamed`).
+
+- `nativeArrayMethod()` - Intercepts the 15 `Array` grimoire methods `set`, `get`, `append`, `pop`, `length`, `is_empty`, `first`, `last`, `clear`, `reverse`, `sort`, `contains`, `index_of`, `remove`, `slice`
+- `objectLess()` - Ordering helper used by native `sort`
+- `objectEquals()` - Equality helper used by native `contains`, `index_of`, `remove`
 
 #### Type System (6 functions)
 - `checkType()` - Type validation
@@ -345,7 +357,8 @@ The Carrion Language is implemented in Go and follows a traditional interpreter 
 - **Comprehensive type system**: Type hints, compatibility checking
 - **Sophisticated error handling**: Stack traces, custom errors
 - **Memory management**: Recursion limits, cleanup functions
-- **Primitive wrapping**: Automatic primitive-to-grimoire conversion
+- **Deferred primitive wrapping**: Primitives stay raw; wrapping to grimoire instances only occurs at method access, removing per-expression allocation overhead
+- **Native fast paths**: Hot-loop infix arithmetic (Integer/Boolean/String) and 15 `Array` methods execute in Go, bypassing the interpreter
 - **Concurrency**: Full goroutine implementation
 - **Advanced imports**: Package resolution, version handling
 
@@ -356,7 +369,7 @@ The Carrion Language is implemented in Go and follows a traditional interpreter 
 ### Object Types (20 total)
 
 #### Primitives
-- `Integer` - 64-bit integers with hashing
+- `Integer` - 64-bit integers with hashing; small values (-5..256) are interned via `object.NewInteger()` to avoid heap allocation on hot paths
 - `Float` - 64-bit floats with hashing  
 - `Boolean` - Boolean values with hashing
 - `String` - String values with hashing
@@ -398,6 +411,7 @@ The Carrion Language is implemented in Go and follows a traditional interpreter 
 - **Rich type system**: 20 distinct object types
 - **Hashable objects**: Support for hash maps and sets
 - **Object-oriented**: Full class system with inheritance
+- **Integer interning**: Small integers (-5..256) are cached at package init via `object.NewInteger()`, sharply reducing allocation pressure in arithmetic-heavy code
 - **Error handling**: Multiple error types with context
 - **Concurrency**: Goroutine management with channels
 
@@ -458,6 +472,51 @@ The Carrion Language is implemented in Go and follows a traditional interpreter 
 - `wrapPrimitiveForBuiltin()` - Wrap primitives for method support
 - `extractIntegerValue()` - Extract integers from objects/instances
 - `jsonToCarrionObject()` - Convert JSON to Carrion objects
+
+---
+
+## 7a. Version Metadata (`src/version/version.go`)
+
+Single source of truth for the running binary's version string. All fields are package-level `var`s so they can be overridden at build time via `go build -ldflags "-X github.com/javanhut/TheCarrionLanguage/src/version.<Field>=<value>"`.
+
+### Fields
+- `Version` - Base semver (major.minor.patch), e.g. `0.1.9`. Default matches the last tagged release for local `go build` invocations without ldflags.
+- `Commit` - Short git SHA the binary was built from. Empty for tagged releases; non-empty for experimental builds.
+- `Channel` - `release`, `experimental`, or `dev` (default).
+- `BuildDate` - RFC3339 UTC build timestamp (optional).
+
+### Functions
+- `Full()` - Returns `v{Version}` for tagged releases, `v{Version}-{Commit[:7]}` for experimental builds.
+- `Short()` - Returns the raw semver without prefix or suffix.
+- `CommitShort()` - Returns the 7-character abbreviated commit hash, or `""`.
+- `IsExperimental()` - Reports whether this binary was built from a non-tagged commit.
+
+The Makefile (`build-linux`, `build-windows`) and `install/install.sh` inject these values via `-ldflags` so every installed binary can report exactly what source it came from.
+
+---
+
+## 7b. Self-Update (`src/update/`)
+
+Implements the `carrion update` subcommand. Separated into five files by concern.
+
+### Files
+- `update.go` - `Run(args)` entry point, flag parsing, `runStable` and `runExperimental` branches, release/experimental asset acquisition
+- `github.go` - GitHub REST client (`releases/latest`, `commits/{branch}`), asset downloader with shared `http.Client`
+- `semver.go` - Minimal `major.minor.patch` parser and `classifyBump()` helper (patch/minor/major)
+- `install.go` - Cross-platform archive extraction (tar.gz for Linux/macOS, zip for Windows), atomic binary swap, git clone, `go build` with injected ldflags, `readSourceVersion()` for picking up repo-bumped semver during experimental builds
+
+### Behavior
+- **Stable channel** (`carrion update`): fetches the latest GitHub release, prefers prebuilt assets matching `runtime.GOOS`/`runtime.GOARCH`, falls back to source build at the release tag.
+- **Experimental channel** (`carrion update --experimental`): tracks `main` HEAD, always builds from source with the commit SHA baked in.
+- **Demotion protection**: if the running binary is `v{semver}-{sha}` (experimental ahead of stable), `carrion update` (stable) warns and refuses to silently replace it with the older tagged release.
+- **Permission handling**: `canWrite(path)` probes the target binary; if not writable, the updater tells the user to re-run with sudo rather than failing mid-install.
+- **Atomic swap**: `os.Rename` on Unix (Linux allows replacing a running binary because the kernel holds the old inode open); on Windows, the current binary is moved aside first since it's locked.
+
+### Flags
+- `--experimental` - Track main HEAD instead of stable releases
+- `--check` - Report status only; no install
+- `--yes` / `-y` - Skip confirmation prompt
+- `--verbose` - Print diagnostic info (asset fallback decisions, etc.)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,62 @@ docker build -t carrion .
 docker run -it carrion
 ```
 
+## Updating Carrion
+
+Once installed, Carrion can update itself in place.
+
+### Stable releases
+
+```bash
+carrion update            # Prompts before installing the latest tagged release
+carrion update --check    # Report status without installing
+carrion update -y         # Skip the confirmation prompt
+```
+
+`carrion update` fetches the latest release from GitHub, downloads the prebuilt asset for your OS/arch when available (`carrion_linux_amd64.tar.gz`, `carrion_darwin_amd64.tar.gz`, `carrion_windows_amd64.zip`), and falls back to a source build at the release tag if no asset is present. Stable updates always take precedence over experimental builds.
+
+### Experimental (latest `main` commit)
+
+```bash
+carrion update --experimental          # Prompts before building from source
+carrion update --experimental --check  # Report status without installing
+```
+
+Experimental updates track the `main` branch: Carrion fetches the latest commit SHA, clones the source, and rebuilds with the commit hash baked into the version string. Requires `git` and a Go 1.24+ toolchain in `PATH`.
+
+### Version format
+
+```bash
+carrion --version
+# Carrion Language version v0.1.10            — tagged release
+# Carrion Language version v0.1.10-a1b2c3d    — experimental (main@a1b2c3d)
+```
+
+Stable releases show plain `v{major}.{minor}.{patch}`; experimental builds append `-{short-sha}` so you always know exactly what's running.
+
+### Permissions
+
+If Carrion is installed in a system directory like `/usr/local/bin`, `carrion update` will tell you to re-run with `sudo`. The binary is replaced atomically — no downtime for long-running processes that already have it open.
+
+## Build & Test Targets
+
+The Makefile exposes the following targets for contributors:
+
+- `make build` — Build the Carrion binary for the host platform
+- `make install` — Install Carrion, Sindri, Mimir, and Bifrost to the system
+- `make uninstall` — Remove installed binaries
+- `make build-linux` / `make build-linux-arm64` — Cross-compile a Linux amd64/arm64 binary tarball
+- `make build-windows` — Cross-compile a Windows amd64 binary zip
+- `make build-mac` (`build-mac-amd64`, `build-mac-arm64`) — Cross-compile macOS tarballs
+- `make build-release` — Build every release artifact in one shot
+- `make build-source` — Produce a source tarball
+- `make test` — Run the full Go test suite (`go test ./src/...`)
+- `make bench` — Run evaluator benchmarks with memory profiling
+- `make sync-version` — Rewrite version references in docs from `src/version/version.go`
+- `make version-check` — Report whether any docs are out of sync (exits 1 if so; CI-friendly)
+- `make tidy` — Run `go mod tidy` across all modules
+- `make bifrost-update` — Initialize and update the Bifrost git submodule
+
 ## Package Management
 
 Carrion integrates with **Bifrost**, the official package manager, for seamless dependency management. Bifrost is automatically installed when you install Carrion.

--- a/install/install.sh
+++ b/install/install.sh
@@ -22,6 +22,18 @@ fi
 
 TARGET_OS=$1
 
+# Detect host architecture so we install a native binary on arm64 machines
+# (Raspberry Pi, AWS Graviton, Apple Silicon, arm64 Windows). Users can force
+# a different arch with `TARGET_ARCH=amd64 ./install.sh linux`.
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)  echo "amd64" ;;
+    arm64|aarch64) echo "arm64" ;;
+    *) echo "amd64" ;;  # fallback
+  esac
+}
+TARGET_ARCH=${TARGET_ARCH:-$(detect_arch)}
+
 # --- 2) Check if Go is Installed ---
 if ! command -v go &> /dev/null; then
   echo "Error: 'go' is not installed or not in your PATH."
@@ -29,21 +41,34 @@ if ! command -v go &> /dev/null; then
   exit 1
 fi
 
+# --- 2a) Resolve version metadata for ldflags injection ---
+# CARRION_VERSION is parsed from the single source of truth in
+# src/version/version.go so bumping the version only needs to happen there.
+CARRION_VERSION=$(awk -F'"' '/^var Version =/{print $2; exit}' src/version/version.go)
+CARRION_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "")
+CARRION_CHANNEL=${CARRION_CHANNEL:-release}
+CARRION_BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+CARRION_LDFLAGS="-X github.com/javanhut/TheCarrionLanguage/src/version.Version=${CARRION_VERSION} \
+-X github.com/javanhut/TheCarrionLanguage/src/version.Commit=${CARRION_COMMIT} \
+-X github.com/javanhut/TheCarrionLanguage/src/version.Channel=${CARRION_CHANNEL} \
+-X github.com/javanhut/TheCarrionLanguage/src/version.BuildDate=${CARRION_BUILD_DATE}"
+
 # --- 3) Build & Install Logic ---
 case "$TARGET_OS" in
   linux)
     echo "Building Carrion for Linux..."
     # Cross-compile for Linux on amd64. Adjust GOARCH if needed (e.g., arm64).
-    GOOS=linux GOARCH=amd64 go build -o carrion ./src
+    GOOS=linux GOARCH=${TARGET_ARCH} go build -ldflags "${CARRION_LDFLAGS}" -o carrion ./src
     
     echo "Building Sindri Testing Framework for Linux..."
     cd cmd/sindri
-    GOOS=linux GOARCH=amd64 go build -o sindri .
+    GOOS=linux GOARCH=${TARGET_ARCH} go build -o sindri .
     cd ../..
     
     echo "Building Mimir Documentation Tool for Linux..."
     cd cmd/mimir
-    GOOS=linux GOARCH=amd64 go build -o mimir .
+    GOOS=linux GOARCH=${TARGET_ARCH} go build -o mimir .
     cd ../..
 
     echo "Building Bifrost Package Manager for Linux..."
@@ -85,22 +110,22 @@ case "$TARGET_OS" in
   windows)
     echo "Building Carrion for Windows..."
     # Cross-compile for Windows on amd64. Adjust GOARCH if needed (e.g., arm64).
-    GOOS=windows GOARCH=amd64 go build -o carrion.exe ./src
+    GOOS=windows GOARCH=${TARGET_ARCH} go build -ldflags "${CARRION_LDFLAGS}" -o carrion.exe ./src
     
     echo "Building Sindri Testing Framework for Windows..."
     cd cmd/sindri
-    GOOS=windows GOARCH=amd64 go build -o sindri.exe .
+    GOOS=windows GOARCH=${TARGET_ARCH} go build -o sindri.exe .
     cd ../..
     
     echo "Building Mimir Documentation Tool for Windows..."
     cd cmd/mimir
-    GOOS=windows GOARCH=amd64 go build -o mimir.exe .
+    GOOS=windows GOARCH=${TARGET_ARCH} go build -o mimir.exe .
     cd ../..
 
     echo "Building Bifrost Package Manager for Windows..."
     if [ -d "bifrost" ]; then
       cd bifrost
-      GOOS=windows GOARCH=amd64 go build -o build/bifrost.exe ./cmd/bifrost
+      GOOS=windows GOARCH=${TARGET_ARCH} go build -o build/bifrost.exe ./cmd/bifrost
       cd ..
     else
       echo "Warning: Bifrost submodule not found. Skipping Bifrost build."
@@ -128,16 +153,16 @@ case "$TARGET_OS" in
   mac)
     echo "Building Carrion for macOS..."
     # Cross-compile for Darwin on amd64. Adjust GOARCH if you're on Apple Silicon (e.g., arm64).
-    GOOS=darwin GOARCH=amd64 go build -o carrion ./src
+    GOOS=darwin GOARCH=${TARGET_ARCH} go build -ldflags "${CARRION_LDFLAGS}" -o carrion ./src
     
     echo "Building Sindri Testing Framework for macOS..."
     cd cmd/sindri
-    GOOS=darwin GOARCH=amd64 go build -o sindri .
+    GOOS=darwin GOARCH=${TARGET_ARCH} go build -o sindri .
     cd ../..
     
     echo "Building Mimir Documentation Tool for macOS..."
     cd cmd/mimir
-    GOOS=darwin GOARCH=amd64 go build -o mimir .
+    GOOS=darwin GOARCH=${TARGET_ARCH} go build -o mimir .
     cd ../..
 
     echo "Building Bifrost Package Manager for macOS..."

--- a/src/evaluator/builtins.go
+++ b/src/evaluator/builtins.go
@@ -42,13 +42,13 @@ var builtins = map[string]*object.Builtin{
 			}
 			switch arg := args[0].(type) {
 			case *object.String:
-				return &object.Integer{Value: int64(len(arg.Value))}
+				return object.NewInteger(int64(len(arg.Value)))
 			case *object.Array:
-				return &object.Integer{Value: int64(len(arg.Elements))}
+				return object.NewInteger(int64(len(arg.Elements)))
 			case *object.Tuple:
-				return &object.Integer{Value: int64(len(arg.Elements))}
+				return object.NewInteger(int64(len(arg.Elements)))
 			case *object.Hash:
-				return &object.Integer{Value: int64(len(arg.Pairs))}
+				return object.NewInteger(int64(len(arg.Pairs)))
 			case *object.Instance:
 				// Handle instances based on their grimoire type
 				switch arg.Grimoire.Name {
@@ -56,21 +56,21 @@ var builtins = map[string]*object.Builtin{
 					if elements, exists := arg.Env.Get("elements"); exists {
 						// Check if elements is a direct Array
 						if arr, isArray := elements.(*object.Array); isArray {
-							return &object.Integer{Value: int64(len(arr.Elements))}
+							return object.NewInteger(int64(len(arr.Elements)))
 						}
 						// Check if elements is an Instance wrapping an Array
 						if elemInstance, isInstance := elements.(*object.Instance); isInstance {
 							// Check if it's an Array instance containing value
 							if value, valueExists := elemInstance.Env.Get("value"); valueExists {
 								if arr, isArray := value.(*object.Array); isArray {
-									return &object.Integer{Value: int64(len(arr.Elements))}
+									return object.NewInteger(int64(len(arr.Elements)))
 								}
 							}
 							// Try to see if it's a direct wrapped array
 							if elemInstance.Grimoire.Name == "Array" {
 								if innerElements, innerExists := elemInstance.Env.Get("elements"); innerExists {
 									if arr, isArray := innerElements.(*object.Array); isArray {
-										return &object.Integer{Value: int64(len(arr.Elements))}
+										return object.NewInteger(int64(len(arr.Elements)))
 									}
 								}
 							}
@@ -80,7 +80,7 @@ var builtins = map[string]*object.Builtin{
 				case "String":
 					if value, exists := arg.Env.Get("value"); exists {
 						if str, isString := value.(*object.String); isString {
-							return &object.Integer{Value: int64(len(str.Value))}
+							return object.NewInteger(int64(len(str.Value)))
 						}
 					}
 					return newError("invalid String instance: missing value")
@@ -277,9 +277,9 @@ var builtins = map[string]*object.Builtin{
 				if err != nil {
 					return newError("cannot convert string to int: %s", err)
 				}
-				return &object.Integer{Value: int64(value)}
+				return object.NewInteger(int64(value))
 			case *object.Float:
-				return &object.Integer{Value: int64(typedArg.Value)}
+				return object.NewInteger(int64(typedArg.Value))
 			case *object.Integer:
 				return typedArg
 			default:
@@ -307,9 +307,9 @@ var builtins = map[string]*object.Builtin{
 				if err != nil {
 					return newError("cannot convert string to int: %s", err)
 				}
-				return &object.Integer{Value: int64(value)}
+				return object.NewInteger(int64(value))
 			case *object.Float:
-				return &object.Integer{Value: int64(typedArg.Value)}
+				return object.NewInteger(int64(typedArg.Value))
 			case *object.Integer:
 				return typedArg
 			default:
@@ -510,11 +510,11 @@ var builtins = map[string]*object.Builtin{
 			var elements []object.Object
 			if step > 0 {
 				for i := start; i < stop; i += step {
-					elements = append(elements, &object.Integer{Value: i})
+					elements = append(elements, object.NewInteger(i))
 				}
 			} else {
 				for i := start; i > stop; i += step {
-					elements = append(elements, &object.Integer{Value: i})
+					elements = append(elements, object.NewInteger(i))
 				}
 			}
 
@@ -548,7 +548,7 @@ var builtins = map[string]*object.Builtin{
 			}
 
 			if maxVal == float64(int64(maxVal)) {
-				return &object.Integer{Value: int64(maxVal)}
+				return object.NewInteger(int64(maxVal))
 			}
 			return &object.Float{Value: maxVal}
 		},
@@ -562,7 +562,7 @@ var builtins = map[string]*object.Builtin{
 			switch v := args[0].(type) {
 			case *object.Integer:
 				if v.Value < 0 {
-					return &object.Integer{Value: -v.Value}
+					return object.NewInteger(-v.Value)
 				}
 				return v
 			case *object.Float:
@@ -666,7 +666,7 @@ var builtins = map[string]*object.Builtin{
 			for i, elem := range elements {
 				tuple := &object.Tuple{
 					Elements: []object.Object{
-						&object.Integer{Value: int64(i)},
+						object.NewInteger(int64(i)),
 						elem,
 					},
 				}
@@ -787,7 +787,7 @@ var builtins = map[string]*object.Builtin{
 			if len(str.Value) != 1 {
 				return newError("ord expects a single character string, got length %d", len(str.Value))
 			}
-			return &object.Integer{Value: int64(str.Value[0])}
+			return object.NewInteger(int64(str.Value[0]))
 		},
 	},
 	"chr": {
@@ -1030,7 +1030,7 @@ func jsonToCarrionObject(data interface{}) object.Object {
 	case float64:
 		// Check if it's an integer
 		if v == float64(int64(v)) {
-			return &object.Integer{Value: int64(v)}
+			return object.NewInteger(int64(v))
 		}
 		return &object.Float{Value: v}
 	case string:

--- a/src/evaluator/evaluator.go
+++ b/src/evaluator/evaluator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -398,50 +399,15 @@ func areValuesEqual(a, b object.Object) bool {
 	}
 }
 
+// wrapPrimitive defers wrapping — primitives stay as raw objects.
+// Wrapping only happens on demand in evalDotExpression when a method is accessed.
 func wrapPrimitive(obj object.Object, env *object.Environment, ctx *CallContext) object.Object {
-	if debugPrimitiveWrapping {
-		fmt.Fprintf(os.Stderr, "WRAP: Evaluating %T, ctx=%s, hasSelf=%t\n", obj, getContextName(ctx), hasSelfInEnv(env))
-	}
+	return obj
+}
 
-	// Don't wrap if we're inside an instance method or initializer
-	// Check current environment and traverse up parent environments
-	if hasSelfInEnv(env) {
-		if debugPrimitiveWrapping {
-			fmt.Fprintf(os.Stderr, "WRAP: Found self in environment, not wrapping\n")
-		}
-		return obj
-	}
-
-	// Don't wrap if we're in a method context (check the call context chain)
-	if isInMethodContext(ctx) {
-		if debugPrimitiveWrapping {
-			fmt.Fprintf(os.Stderr, "WRAP: In method context %s, not wrapping\n", getContextName(ctx))
-		}
-		return obj
-	}
-
-	// Don't wrap if this is in a function call context that expects primitives
-	if ctx != nil && ctx.FunctionName != "" {
-		// Don't wrap arguments to builtin functions (except for input functions that should return String instances and pairs() that should return Array instances)
-		if isBuiltinFunction(ctx.FunctionName) && !shouldWrapStringResult(ctx.FunctionName) && ctx.FunctionName != "pairs" {
-			if debugPrimitiveWrapping {
-				fmt.Fprintf(os.Stderr, "WRAP: Builtin function %s, not wrapping\n", ctx.FunctionName)
-			}
-			return obj
-		}
-		// Don't wrap arguments to grimoire constructors
-		if isGrimoireConstructor(ctx.FunctionName, env) {
-			if debugPrimitiveWrapping {
-				fmt.Fprintf(os.Stderr, "WRAP: Grimoire constructor %s, not wrapping\n", ctx.FunctionName)
-			}
-			return obj
-		}
-	}
-
-	if debugPrimitiveWrapping {
-		fmt.Fprintf(os.Stderr, "WRAP: Wrapping %T in context %s\n", obj, getContextName(ctx))
-	}
-
+// wrapPrimitiveForMethod creates an Instance wrapping a primitive for method access.
+// Called only from evalDotExpression when a method is actually invoked on a primitive.
+func wrapPrimitiveForMethod(obj object.Object, env *object.Environment) object.Object {
 	var grimName string
 
 	switch obj.Type() {
@@ -456,29 +422,32 @@ func wrapPrimitive(obj object.Object, env *object.Environment, ctx *CallContext)
 	case object.ARRAY_OBJ:
 		grimName = "Array"
 	default:
-		return obj // Not a primitive, return as is
+		return obj
 	}
 
-	// Try to find the grimoire
-	if grimObj, ok := env.Get(grimName); ok {
+	// Try stdlib environment first, then local
+	var grimObj object.Object
+	var ok bool
+	if stdlibEnv != nil {
+		grimObj, ok = stdlibEnv.Get(grimName)
+	}
+	if !ok {
+		grimObj, ok = env.Get(grimName)
+	}
+
+	if ok {
 		if grimoire, isGrim := grimObj.(*object.Grimoire); isGrim {
-			// Create instance exactly like the normal grimoire constructor
 			instance := &object.Instance{
 				Grimoire: grimoire,
 				Env:      object.NewEnclosedEnvironment(grimoire.Env),
 			}
-
-			// Set self reference
 			instance.Env.Set("self", instance)
 
-			// Handle different types appropriately
 			if grimName == "Array" {
-				// For arrays, set the elements directly
 				if arrayObj, isArray := obj.(*object.Array); isArray {
 					instance.Env.Set("elements", arrayObj)
 				}
 			} else {
-				// For other primitives, set the value
 				instance.Env.Set("value", obj)
 			}
 
@@ -486,7 +455,6 @@ func wrapPrimitive(obj object.Object, env *object.Environment, ctx *CallContext)
 		}
 	}
 
-	// If grimoire not found, return the original object
 	return obj
 }
 
@@ -604,9 +572,10 @@ func Eval(node ast.Node, env *object.Environment, ctx *CallContext) object.Objec
 		}
 	}
 
+	// Save and restore CurrentContext without defer (avoid closure allocation per Eval call)
 	oldContext := CurrentContext
 	CurrentContext = ctx
-	defer func() { CurrentContext = oldContext }()
+
 	// Create a new call context if node is a function call
 	if callExp, ok := node.(*ast.CallExpression); ok {
 		funcName := ""
@@ -626,6 +595,13 @@ func Eval(node ast.Node, env *object.Environment, ctx *CallContext) object.Objec
 		ctx = newCtx
 	}
 
+	result := evalNode(node, env, ctx)
+	CurrentContext = oldContext
+	return result
+}
+
+// evalNode is the inner dispatch loop, separated to avoid defer overhead in Eval.
+func evalNode(node ast.Node, env *object.Environment, ctx *CallContext) object.Object {
 	switch node := node.(type) {
 	case *ast.Program:
 		return evalProgram(node, env, ctx)
@@ -765,7 +741,7 @@ func Eval(node ast.Node, env *object.Environment, ctx *CallContext) object.Objec
 		return evalPostfixIncrementDecrement(node.Operator, node, env, ctx)
 
 	case *ast.IntegerLiteral:
-		primitive := &object.Integer{Value: node.Value}
+		primitive := object.NewInteger(node.Value)
 		return wrapPrimitive(primitive, env, ctx)
 	case *ast.FloatLiteral:
 		primitive := &object.Float{Value: node.Value}
@@ -814,20 +790,7 @@ func Eval(node ast.Node, env *object.Environment, ctx *CallContext) object.Objec
 			return elements[0]
 		}
 
-		// Create Array instance if Array grimoire exists
-		if grimObj, ok := env.Get("Array"); ok {
-			if grimoire, isGrim := grimObj.(*object.Grimoire); isGrim {
-				instance := &object.Instance{
-					Grimoire: grimoire,
-					Env:      object.NewEnclosedEnvironment(grimoire.Env),
-				}
-				// Set the elements directly in the instance environment
-				instance.Env.Set("elements", &object.Array{Elements: elements})
-				return instance
-			}
-		}
-
-		// Fallback to regular array
+		// Return raw array — wrapping deferred to DotExpression on method access
 		return &object.Array{Elements: elements}
 
 	case *ast.StringLiteral:
@@ -1646,6 +1609,14 @@ func evalIndexAssignment(
 		array.Pairs[key.HashKey()] = pair
 		return value
 
+	case *object.Instance:
+		// Unwrap Instance-wrapped arrays and hashes
+		unwrapped := unwrapPrimitive(array)
+		if unwrapped != array {
+			return evalIndexAssignment(unwrapped, index, value, node, ctx)
+		}
+		return newErrorWithTrace("index assignment not supported: %s", node, ctx, array.Type())
+
 	default:
 		return newErrorWithTrace("index assignment not supported: %s", node, ctx, array.Type())
 	}
@@ -1919,8 +1890,264 @@ func bindMethodParameters(
 	}
 }
 
+// wrapArrayInstance returns a new Array grimoire Instance wrapping the given
+// raw array, matching the return type of the Carrion-stdlib Array methods
+// (which return `self.elements + [...]` that the evaluator lifts into an
+// Instance). Without this, native `sort`/`reverse` would return raw
+// *object.Array and break callers that introspect the type.
+func wrapArrayInstance(arrayGrim *object.Grimoire, arr *object.Array) object.Object {
+	if arrayGrim == nil {
+		return arr
+	}
+	inst := &object.Instance{
+		Grimoire: arrayGrim,
+		Env:      object.NewEnclosedEnvironment(arrayGrim.Env),
+	}
+	inst.Env.Set("self", inst)
+	inst.Env.Set("elements", arr)
+	return inst
+}
+
 // evalGrimoireMethodCall executes a method call on a grimoire instance
 // Sets MethodGrimoire to the method's defining class for proper super resolution
+// nativeArrayMethod handles performance-critical Array methods in Go instead of
+// interpreting them in Carrion. Returns (result, true) if handled, (nil, false) otherwise.
+func nativeArrayMethod(instance *object.Instance, methodName string, args []object.Object, ctx *CallContext) (object.Object, bool) {
+	if instance.Grimoire.Name != "Array" {
+		return nil, false
+	}
+
+	elemObj, exists := instance.Env.Get("elements")
+	if !exists {
+		return nil, false
+	}
+	arr, isArray := elemObj.(*object.Array)
+	if !isArray {
+		return nil, false
+	}
+
+	switch methodName {
+	case "set":
+		if len(args) != 2 {
+			return nil, false
+		}
+		idxObj := unwrapPrimitive(args[0])
+		intIdx, ok := idxObj.(*object.Integer)
+		if !ok {
+			return nil, false
+		}
+		idx := intIdx.Value
+		if idx < 0 {
+			idx = int64(len(arr.Elements)) + idx
+		}
+		if idx >= 0 && idx < int64(len(arr.Elements)) {
+			arr.Elements[idx] = args[1]
+		}
+		return NONE, true
+
+	case "get":
+		if len(args) != 1 {
+			return nil, false
+		}
+		idxObj := unwrapPrimitive(args[0])
+		intIdx, ok := idxObj.(*object.Integer)
+		if !ok {
+			return nil, false
+		}
+		idx := intIdx.Value
+		if idx < 0 {
+			idx = int64(len(arr.Elements)) + idx
+		}
+		if idx < 0 || idx >= int64(len(arr.Elements)) {
+			return NONE, true
+		}
+		return arr.Elements[idx], true
+
+	case "append":
+		if len(args) != 1 {
+			return nil, false
+		}
+		arr.Elements = append(arr.Elements, args[0])
+		return NONE, true
+
+	case "pop":
+		if len(arr.Elements) == 0 {
+			return NONE, true
+		}
+		last := arr.Elements[len(arr.Elements)-1]
+		arr.Elements = arr.Elements[:len(arr.Elements)-1]
+		return last, true
+
+	case "length":
+		return object.NewInteger(int64(len(arr.Elements))), true
+
+	case "is_empty":
+		return nativeBoolToBooleanObject(len(arr.Elements) == 0), true
+
+	case "first":
+		if len(arr.Elements) == 0 {
+			return NONE, true
+		}
+		return arr.Elements[0], true
+
+	case "last":
+		if len(arr.Elements) == 0 {
+			return NONE, true
+		}
+		return arr.Elements[len(arr.Elements)-1], true
+
+	case "clear":
+		arr.Elements = arr.Elements[:0]
+		return NONE, true
+
+	case "reverse":
+		n := len(arr.Elements)
+		result := make([]object.Object, n)
+		for i := 0; i < n; i++ {
+			result[i] = arr.Elements[n-1-i]
+		}
+		return wrapArrayInstance(instance.Grimoire, &object.Array{Elements: result}), true
+
+	case "sort":
+		// Create a copy and sort it (non-mutating, matches Carrion semantics)
+		n := len(arr.Elements)
+		sorted := make([]object.Object, n)
+		copy(sorted, arr.Elements)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return objectLess(sorted[i], sorted[j])
+		})
+		return wrapArrayInstance(instance.Grimoire, &object.Array{Elements: sorted}), true
+
+	case "contains":
+		if len(args) != 1 {
+			return nil, false
+		}
+		target := args[0]
+		for _, elem := range arr.Elements {
+			if objectEquals(elem, target) {
+				return TRUE, true
+			}
+		}
+		return FALSE, true
+
+	case "index_of":
+		if len(args) != 1 {
+			return nil, false
+		}
+		target := args[0]
+		for i, elem := range arr.Elements {
+			if objectEquals(elem, target) {
+				return object.NewInteger(int64(i)), true
+			}
+		}
+		return object.NewInteger(-1), true
+
+	case "remove":
+		if len(args) != 1 {
+			return nil, false
+		}
+		target := args[0]
+		found := false
+		newElements := make([]object.Object, 0, len(arr.Elements))
+		for _, elem := range arr.Elements {
+			if !found && objectEquals(elem, target) {
+				found = true
+				continue
+			}
+			newElements = append(newElements, elem)
+		}
+		arr.Elements = newElements
+		return nativeBoolToBooleanObject(found), true
+
+	case "slice":
+		if len(args) != 2 {
+			return nil, false
+		}
+		startObj := unwrapPrimitive(args[0])
+		endObj := unwrapPrimitive(args[1])
+		startInt, ok1 := startObj.(*object.Integer)
+		endInt, ok2 := endObj.(*object.Integer)
+		if !ok1 || !ok2 {
+			return nil, false
+		}
+		start := startInt.Value
+		end := endInt.Value
+		n := int64(len(arr.Elements))
+		if start < 0 {
+			start = n + start
+		}
+		if end < 0 {
+			end = n + end
+		}
+		result := make([]object.Object, 0)
+		for i := start; i < end; i++ {
+			if i >= 0 && i < n {
+				result = append(result, arr.Elements[i])
+			}
+		}
+		return &object.Array{Elements: result}, true
+	}
+
+	return nil, false
+}
+
+// objectLess compares two objects for sort ordering (less-than).
+func objectLess(a, b object.Object) bool {
+	a = unwrapPrimitive(a)
+	b = unwrapPrimitive(b)
+
+	switch av := a.(type) {
+	case *object.Integer:
+		if bv, ok := b.(*object.Integer); ok {
+			return av.Value < bv.Value
+		}
+		if bv, ok := b.(*object.Float); ok {
+			return float64(av.Value) < bv.Value
+		}
+	case *object.Float:
+		if bv, ok := b.(*object.Float); ok {
+			return av.Value < bv.Value
+		}
+		if bv, ok := b.(*object.Integer); ok {
+			return av.Value < float64(bv.Value)
+		}
+	case *object.String:
+		if bv, ok := b.(*object.String); ok {
+			return av.Value < bv.Value
+		}
+	}
+	return false
+}
+
+// objectEquals compares two objects for equality.
+func objectEquals(a, b object.Object) bool {
+	a = unwrapPrimitive(a)
+	b = unwrapPrimitive(b)
+
+	switch av := a.(type) {
+	case *object.Integer:
+		if bv, ok := b.(*object.Integer); ok {
+			return av.Value == bv.Value
+		}
+	case *object.Float:
+		if bv, ok := b.(*object.Float); ok {
+			return av.Value == bv.Value
+		}
+	case *object.String:
+		if bv, ok := b.(*object.String); ok {
+			return av.Value == bv.Value
+		}
+	case *object.Boolean:
+		if bv, ok := b.(*object.Boolean); ok {
+			return av.Value == bv.Value
+		}
+	case *object.None:
+		_, ok := b.(*object.None)
+		return ok
+	}
+	return a == b
+}
+
 func evalGrimoireMethodCall(
 	instance *object.Instance,
 	methodName string,
@@ -1928,6 +2155,11 @@ func evalGrimoireMethodCall(
 	env *object.Environment,
 	ctx *CallContext,
 ) object.Object {
+	// Fast path: native Go implementation for Array methods
+	if result, handled := nativeArrayMethod(instance, methodName, args, ctx); handled {
+		return result
+	}
+
 	method, ok := instance.Grimoire.Methods[methodName]
 	if !ok {
 		// Get available methods and find similar names for suggestions
@@ -2010,6 +2242,11 @@ func evalBoundMethodCall(
 	method := boundMethod.Method
 	instance := boundMethod.Instance
 	methodName := boundMethod.Name
+
+	// Fast path: native Go implementation for Array methods
+	if result, handled := nativeArrayMethod(instance, methodName, args, ctx); handled {
+		return result
+	}
 
 	// Create isolated method environment from the method's original environment, not instance env
 	methodEnv := object.NewEnclosedEnvironment(method.Env)
@@ -2455,6 +2692,13 @@ func evalBoundMethodCallWithNamed(
 	instance := bm.Instance
 	method := bm.Method
 
+	// Fast path: native Go implementation for Array methods (when no named args)
+	if len(namedArgs) == 0 {
+		if result, handled := nativeArrayMethod(instance, bm.Name, positionalArgs, ctx); handled {
+			return result
+		}
+	}
+
 	// Create method environment
 	methodEnv := object.NewEnclosedEnvironment(instance.Grimoire.Env)
 	methodEnv.Set("self", instance)
@@ -2727,61 +2971,10 @@ func evalDotExpression(
 		}
 	}
 
-	// Wrap primitives to allow method access (e.g., self.some_string.upper())
-	// This enables calling methods on primitives stored in instance variables
+	// Wrap primitives on demand for method access (e.g., "hello".upper())
 	switch leftObj.Type() {
 	case object.INTEGER_OBJ, object.FLOAT_OBJ, object.STRING_OBJ, object.BOOLEAN_OBJ, object.ARRAY_OBJ:
-		// Determine the grimoire name based on the primitive type
-		var grimName string
-		switch leftObj.Type() {
-		case object.INTEGER_OBJ:
-			grimName = "Integer"
-		case object.FLOAT_OBJ:
-			grimName = "Float"
-		case object.STRING_OBJ:
-			grimName = "String"
-		case object.BOOLEAN_OBJ:
-			grimName = "Boolean"
-		case object.ARRAY_OBJ:
-			grimName = "Array"
-		}
-
-		// Find the grimoire in the stdlib environment (not local env)
-		// We need to use stdlibEnv to access primitive grimoires that are globally available
-
-		// Try stdlib environment first (where String, Integer, etc. grimoires are defined)
-		var grimObj object.Object
-		var ok bool
-		if stdlibEnv != nil {
-			grimObj, ok = stdlibEnv.Get(grimName)
-		}
-
-		// Fallback to local environment if not found in stdlib
-		if !ok {
-			grimObj, ok = env.Get(grimName)
-		}
-
-		if ok {
-			if grimoire, isGrim := grimObj.(*object.Grimoire); isGrim {
-				// Create an instance wrapping the primitive
-				instance := &object.Instance{
-					Grimoire: grimoire,
-					Env:      object.NewEnclosedEnvironment(grimoire.Env),
-				}
-				instance.Env.Set("self", instance)
-
-				// Set the primitive value
-				if grimName == "Array" {
-					if arrayObj, isArray := leftObj.(*object.Array); isArray {
-						instance.Env.Set("elements", arrayObj)
-					}
-				} else {
-					instance.Env.Set("value", leftObj)
-				}
-
-				leftObj = instance
-			}
-		}
+		leftObj = wrapPrimitiveForMethod(leftObj, env)
 	}
 
 	instance, ok := leftObj.(*object.Instance)
@@ -3497,7 +3690,7 @@ func evalPrefixExpression(
 			return newErrorWithTrace("unsupported operand type for ~: %s", node, ctx, unwrappedRight.Type())
 		}
 
-		return wrapPrimitive(&object.Integer{Value: ^intOperand.Value}, env, ctx)
+		return wrapPrimitive(object.NewInteger(^intOperand.Value), env, ctx)
 
 	// Prefix increment and decrement operators
 	case "++":
@@ -3515,8 +3708,8 @@ func evalPrefixExpression(
 			return newErrorWithTrace("prefix '++' operator requires an integer", node, ctx)
 		}
 		newVal := intObj.Value + 1
-		env.Set(ident.Value, &object.Integer{Value: newVal})
-		return &object.Integer{Value: newVal}
+		env.Set(ident.Value, object.NewInteger(newVal))
+		return object.NewInteger(newVal)
 	case "--":
 		ident, ok := node.Right.(*ast.Identifier)
 		if !ok {
@@ -3531,8 +3724,8 @@ func evalPrefixExpression(
 			return newErrorWithTrace("prefix '--' operator requires an integer", node, ctx)
 		}
 		newValDec := intObj.Value - 1
-		env.Set(ident.Value, &object.Integer{Value: newValDec})
-		return &object.Integer{Value: newValDec}
+		env.Set(ident.Value, object.NewInteger(newValDec))
+		return object.NewInteger(newValDec)
 	case "-":
 		right := Eval(node.Right, env, ctx)
 		return evalMinusPrefixOperatorExpression(right, env, ctx)
@@ -3549,6 +3742,24 @@ func evalInfixExpression(
 	ctx *CallContext,
 	env *object.Environment,
 ) object.Object {
+	// Fast path: if both operands are already raw primitives (most common case in loops),
+	// skip unwrapPrimitive entirely and go straight to type-specific evaluation.
+	if leftInt, ok := left.(*object.Integer); ok {
+		if rightInt, ok := right.(*object.Integer); ok {
+			return evalIntegerInfixExpression(operator, leftInt, rightInt, node, ctx, env)
+		}
+	}
+	if leftBool, ok := left.(*object.Boolean); ok {
+		if rightBool, ok := right.(*object.Boolean); ok {
+			return evalBooleanInfixExpression(operator, leftBool, rightBool, node, ctx)
+		}
+	}
+	if leftStr, ok := left.(*object.String); ok {
+		if rightStr, ok := right.(*object.String); ok {
+			return evalStringInfixExpression(operator, leftStr, rightStr, node, ctx, env)
+		}
+	}
+
 	if debugPrimitiveWrapping && operator == "//" {
 		fmt.Fprintf(os.Stderr, "EVAL_INFIX: %s between %T and %T in %s\n", operator, left, right, getContextName(ctx))
 	}
@@ -3774,23 +3985,18 @@ func evalInfixExpression(
 		rightVal := toFloat(unwrappedRight)
 		switch operator {
 		case "+":
-			primitive := &object.Float{Value: leftVal + rightVal}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: leftVal + rightVal}
 		case "-":
-			primitive := &object.Float{Value: leftVal - rightVal}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: leftVal - rightVal}
 		case "*":
-			primitive := &object.Float{Value: leftVal * rightVal}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: leftVal * rightVal}
 		case "/":
 			if rightVal == 0 {
 				return newErrorWithTrace("division by zero", node, ctx)
 			}
-			primitive := &object.Float{Value: leftVal / rightVal}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: leftVal / rightVal}
 		case "**":
-			primitive := &object.Float{Value: math.Pow(leftVal, rightVal)}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: math.Pow(leftVal, rightVal)}
 		case "<":
 			return nativeBoolToBooleanObject(leftVal < rightVal)
 		case ">":
@@ -3852,8 +4058,7 @@ func evalStringInfixExpression(
 
 	switch operator {
 	case "+":
-		primitive := &object.String{Value: leftVal + rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return &object.String{Value: leftVal + rightVal}
 	case "==":
 		return nativeBoolToBooleanObject(leftVal == rightVal)
 	case "!=":
@@ -3924,20 +4129,22 @@ func evalPrefixIncrementDecrement(
 				node, ctx, operator, operand.Value)
 		}
 
+		var newValue int64
 		if operator == "++" {
-			intObj.Value += 1
-		} else if operator == "--" {
-			intObj.Value -= 1
+			newValue = intObj.Value + 1
+		} else {
+			newValue = intObj.Value - 1
 		}
+		newIntObj := object.NewInteger(newValue)
 
 		// If it was an instance, update the instance's value
 		if instance, ok := obj.(*object.Instance); ok {
-			instance.Env.Set("value", intObj)
+			instance.Env.Set("value", newIntObj)
 			env.SetWithGlobalCheck(operand.Value, instance)
 		} else {
-			env.SetWithGlobalCheck(operand.Value, intObj)
+			env.SetWithGlobalCheck(operand.Value, newIntObj)
 		}
-		return intObj
+		return newIntObj
 
 	default:
 		return newErrorWithTrace("prefix '%s' operator requires an integer or identifier",
@@ -3987,7 +4194,7 @@ func evalPostfixIncrementDecrement(
 			newValue = oldValue - 1
 		}
 
-		newIntObj := &object.Integer{Value: newValue}
+		newIntObj := object.NewInteger(newValue)
 
 		// If it was an instance, update the instance's value
 		if instance, ok := obj.(*object.Instance); ok {
@@ -3997,7 +4204,7 @@ func evalPostfixIncrementDecrement(
 			env.SetWithGlobalCheck(operand.Value, newIntObj)
 		}
 
-		return &object.Integer{Value: oldValue}
+		return object.NewInteger(oldValue)
 	default:
 		return newErrorWithTrace("postfix '%s' operator requires an integer or identifier",
 			node, ctx, operator)
@@ -4035,7 +4242,7 @@ func evalMinusPrefixOperatorExpression(
 	}
 	switch unwrapped := unwrapped.(type) {
 	case *object.Integer:
-		return &object.Integer{Value: -unwrapped.Value}
+		return object.NewInteger(-unwrapped.Value)
 	case *object.Float:
 		return &object.Float{Value: -unwrapped.Value}
 	default:
@@ -4054,38 +4261,29 @@ func evalIntegerInfixExpression(
 	leftVal := left.(*object.Integer).Value
 	rightVal := right.(*object.Integer).Value
 
-	if debugPrimitiveWrapping && operator == "//" {
-		fmt.Fprintf(os.Stderr, "INTDIV: %d %s %d in %s\n", leftVal, operator, rightVal, getContextName(ctx))
-	}
 	switch operator {
 	case "+":
-		primitive := &object.Integer{Value: leftVal + rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal + rightVal)
 	case "-":
-		primitive := &object.Integer{Value: leftVal - rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal - rightVal)
 	case "*":
-		primitive := &object.Integer{Value: leftVal * rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal * rightVal)
 	case "/":
 		if rightVal == 0 {
 			return newErrorWithTrace("division by zero", node, ctx)
 		}
-		primitive := &object.Integer{Value: leftVal / rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal / rightVal)
 	case "%":
 		if rightVal == 0 {
 			return newErrorWithTrace("modulo by zero", node, ctx)
 		}
-		primitive := &object.Integer{Value: leftVal % rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal % rightVal)
 	case "<":
 		return nativeBoolToBooleanObject(leftVal < rightVal)
 	case ">":
 		return nativeBoolToBooleanObject(leftVal > rightVal)
 	case "**":
-		primitive := &object.Integer{Value: int64(math.Pow(float64(leftVal), float64(rightVal)))}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(int64(math.Pow(float64(leftVal), float64(rightVal))))
 	case "==":
 		return nativeBoolToBooleanObject(leftVal == rightVal)
 	case "!=":
@@ -4095,26 +4293,20 @@ func evalIntegerInfixExpression(
 	case "<=":
 		return nativeBoolToBooleanObject(leftVal <= rightVal)
 	case "<<":
-		primitive := &object.Integer{Value: leftVal << uint(rightVal)}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal << uint(rightVal))
 	case ">>":
-		primitive := &object.Integer{Value: leftVal >> uint(rightVal)}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal >> uint(rightVal))
 	case "&":
-		primitive := &object.Integer{Value: leftVal & rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal & rightVal)
 	case "^":
-		primitive := &object.Integer{Value: leftVal ^ rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal ^ rightVal)
 	case "|":
-		primitive := &object.Integer{Value: leftVal | rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal | rightVal)
 	case "//":
 		if rightVal == 0 {
 			return newErrorWithTrace("integer division by zero", node, ctx)
 		}
-		primitive := &object.Integer{Value: leftVal / rightVal}
-		return wrapPrimitive(primitive, env, ctx)
+		return object.NewInteger(leftVal / rightVal)
 	default:
 		return newErrorWithTrace("unknown operator: %s %s %s",
 			node, ctx, left.Type(), operator, right.Type())
@@ -4207,20 +4399,16 @@ func applyCompoundOperator(
 		}
 		switch operator {
 		case "+=":
-			primitive := &object.Integer{Value: lInt.Value + rInt.Value}
-			return wrapPrimitive(primitive, env, ctx)
+			return object.NewInteger(lInt.Value + rInt.Value)
 		case "-=":
-			primitive := &object.Integer{Value: lInt.Value - rInt.Value}
-			return wrapPrimitive(primitive, env, ctx)
+			return object.NewInteger(lInt.Value - rInt.Value)
 		case "*=":
-			primitive := &object.Integer{Value: lInt.Value * rInt.Value}
-			return wrapPrimitive(primitive, env, ctx)
+			return object.NewInteger(lInt.Value * rInt.Value)
 		case "/=":
 			if rInt.Value == 0 {
 				return newErrorWithTrace("division by zero", node, ctx)
 			}
-			primitive := &object.Integer{Value: lInt.Value / rInt.Value}
-			return wrapPrimitive(primitive, env, ctx)
+			return object.NewInteger(lInt.Value / rInt.Value)
 		default:
 			return newErrorWithTrace("unknown operator: %s", node, ctx, operator)
 		}
@@ -4235,20 +4423,16 @@ func applyCompoundOperator(
 		}
 		switch operator {
 		case "+=":
-			primitive := &object.Float{Value: lFloat.Value + rFloat.Value}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: lFloat.Value + rFloat.Value}
 		case "-=":
-			primitive := &object.Float{Value: lFloat.Value - rFloat.Value}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: lFloat.Value - rFloat.Value}
 		case "*=":
-			primitive := &object.Float{Value: lFloat.Value * rFloat.Value}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: lFloat.Value * rFloat.Value}
 		case "/=":
 			if rFloat.Value == 0 {
 				return newErrorWithTrace("division by zero", node, ctx)
 			}
-			primitive := &object.Float{Value: lFloat.Value / rFloat.Value}
-			return wrapPrimitive(primitive, env, ctx)
+			return &object.Float{Value: lFloat.Value / rFloat.Value}
 		default:
 			return newErrorWithTrace("unknown operator: %s", node, ctx, operator)
 		}
@@ -4274,8 +4458,7 @@ func applyCompoundOperator(
 	if operator == "+=" {
 		if lStr, ok := extractString(leftVal); ok {
 			if rStr, ok := extractString(rightVal); ok {
-				primitive := &object.String{Value: lStr.Value + rStr.Value}
-				return wrapPrimitive(primitive, env, ctx)
+				return &object.String{Value: lStr.Value + rStr.Value}
 			}
 		}
 	}
@@ -4403,6 +4586,15 @@ func evalWhileStatement(
 		env:          env,
 	}
 
+	// Pre-allocate a single statement context and reuse it each iteration
+	stmtCtx := &CallContext{
+		FunctionName: "while_statement",
+		Parent:       whileCtx,
+		env:          env,
+	}
+
+	n := len(node.Body.Statements)
+
 	for {
 		condition := Eval(node.Condition, env, whileCtx)
 		if isError(condition) {
@@ -4412,17 +4604,10 @@ func evalWhileStatement(
 			break
 		}
 
-		n := len(node.Body.Statements)
 		var controlSignal object.Object = nil
 
 		for i := 0; i < n-1; i++ {
-			stmtCtx := &CallContext{
-				FunctionName: "while_statement",
-				Node:         node.Body.Statements[i],
-				Parent:       whileCtx,
-				env:          env,
-			}
-
+			stmtCtx.Node = node.Body.Statements[i]
 			res := Eval(node.Body.Statements[i], env, stmtCtx)
 
 			rt := getObjectType(res)
@@ -4434,14 +4619,9 @@ func evalWhileStatement(
 			}
 		}
 
-		if n > 0 {
-			lastStmtCtx := &CallContext{
-				FunctionName: "while_last_statement",
-				Node:         node.Body.Statements[n-1],
-				Parent:       whileCtx,
-				env:          env,
-			}
-			_ = Eval(node.Body.Statements[n-1], env, lastStmtCtx)
+		if controlSignal == nil && n > 0 {
+			stmtCtx.Node = node.Body.Statements[n-1]
+			_ = Eval(node.Body.Statements[n-1], env, stmtCtx)
 		}
 
 		if controlSignal != nil {
@@ -4482,6 +4662,13 @@ func isTruthy(obj object.Object) bool {
 		return len(obj.Pairs) > 0
 	case *object.None:
 		return false
+	case *object.Instance:
+		// Unwrap primitive instances (e.g., Boolean(false) should be falsy)
+		unwrapped := unwrapPrimitive(obj)
+		if unwrapped != obj {
+			return isTruthy(unwrapped)
+		}
+		return true
 	default:
 		return true
 	}
@@ -5471,7 +5658,7 @@ func unpackArray(
 			// Create indices array
 			indices := &object.Array{Elements: []object.Object{}}
 			for i := range arr.Elements {
-				indices.Elements = append(indices.Elements, &object.Integer{Value: int64(i)})
+				indices.Elements = append(indices.Elements, object.NewInteger(int64(i)))
 			}
 
 			// Assign to variables

--- a/src/evaluator/evaluator_bench_test.go
+++ b/src/evaluator/evaluator_bench_test.go
@@ -1,0 +1,80 @@
+package evaluator
+
+import (
+	"testing"
+
+	"github.com/javanhut/TheCarrionLanguage/src/lexer"
+	"github.com/javanhut/TheCarrionLanguage/src/object"
+	"github.com/javanhut/TheCarrionLanguage/src/parser"
+)
+
+func benchEval(b *testing.B, input string) {
+	l := lexer.New(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		b.Fatalf("parse errors: %v", p.Errors())
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		env := object.NewEnvironment()
+		ctx := &CallContext{
+			FunctionName:      "<bench>",
+			Node:              program,
+			Parent:            nil,
+			IsDirectExecution: true,
+			env:               env,
+		}
+		Eval(program, env, ctx)
+	}
+}
+
+func BenchmarkIntegerLoop(b *testing.B) {
+	benchEval(b, `
+i = 0
+while i < 10000:
+    i = i + 1
+`)
+}
+
+func BenchmarkArithmetic(b *testing.B) {
+	benchEval(b, `
+x = 0
+i = 0
+while i < 5000:
+    x = x + i * 2 - 1
+    i = i + 1
+`)
+}
+
+func BenchmarkFibonacci(b *testing.B) {
+	benchEval(b, `
+spell fib(n):
+    if n < 2:
+        return n
+    return fib(n - 1) + fib(n - 2)
+fib(20)
+`)
+}
+
+func BenchmarkArrayBuild(b *testing.B) {
+	benchEval(b, `
+arr = []
+i = 0
+while i < 1000:
+    arr = arr + [i]
+    i = i + 1
+`)
+}
+
+func BenchmarkStringConcat(b *testing.B) {
+	benchEval(b, `
+s = ""
+i = 0
+while i < 1000:
+    s = s + "a"
+    i = i + 1
+`)
+}

--- a/src/main.go
+++ b/src/main.go
@@ -10,9 +10,9 @@ import (
 	"github.com/javanhut/TheCarrionLanguage/src/evaluator"
 	"github.com/javanhut/TheCarrionLanguage/src/object"
 	"github.com/javanhut/TheCarrionLanguage/src/repl"
+	"github.com/javanhut/TheCarrionLanguage/src/update"
+	"github.com/javanhut/TheCarrionLanguage/src/version"
 )
-
-var versionNum string = "0.1.9"
 
 const CROW_IMAGE = `
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣀⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀
@@ -33,8 +33,21 @@ const CROW_IMAGE = `
   `
 
 func main() {
+	// Subcommand routing — must run before flag.Parse because subcommands own
+	// their own flag sets (e.g. `carrion update --experimental`).
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "update":
+			if err := update.Run(os.Args[2:]); err != nil {
+				fmt.Fprintln(os.Stderr, "Error:", err)
+				os.Exit(2)
+			}
+			os.Exit(update.CheckExitCode())
+		}
+	}
+
 	// Define command line flags
-	version := flag.Bool("version", false, "Prints out the Current version of the Carrion Language")
+	versionFlag := flag.Bool("version", false, "Prints out the Current version of the Carrion Language")
 	shortVersion := flag.Bool("v", false, "Prints out the current Carrion Version (short from)")
 	idebug := flag.Bool("idebug", false, "Enable interpreter debugging")
 	id := flag.Bool("id", false, "Enable interpreter debugging (short form)")
@@ -67,10 +80,8 @@ func main() {
 	env.SetDebugConfig(debugConfig)
 
 	// Print out the version of Carrion Lang
-	if *version || *shortVersion {
-		print := fmt.Println
-		versionInfo := fmt.Sprintf("Carrion Language version %v", versionNum)
-		print(versionInfo)
+	if *versionFlag || *shortVersion {
+		fmt.Printf("Carrion Language version %s\n", version.Full())
 		return
 	}
 

--- a/src/object/environment.go
+++ b/src/object/environment.go
@@ -17,9 +17,9 @@ func NewEnvironment() *Environment {
 }
 
 func NewEnclosedEnvironment(outer *Environment) *Environment {
-	env := NewEnvironment()
-	env.outer = outer
-	return env
+	// Pre-size for typical method/closure environments (self + a few params)
+	s := make(map[string]Object, 4)
+	return &Environment{store: s, outer: outer, globalVars: nil}
 }
 
 func (e *Environment) Get(name string) (Object, bool) {

--- a/src/object/object.go
+++ b/src/object/object.go
@@ -53,6 +53,26 @@ type Integer struct {
 func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
 func (i *Integer) Inspect() string  { return fmt.Sprintf("%d", i.Value) }
 
+// integerCache caches small integers (-5 to 256) to avoid heap allocations.
+const intCacheMin = -5
+const intCacheMax = 256
+
+var integerCache [intCacheMax - intCacheMin + 1]*Integer
+
+func init() {
+	for i := int64(intCacheMin); i <= intCacheMax; i++ {
+		integerCache[i-intCacheMin] = &Integer{Value: i}
+	}
+}
+
+// NewInteger returns an *Integer, using the cache for small values.
+func NewInteger(value int64) *Integer {
+	if value >= intCacheMin && value <= intCacheMax {
+		return integerCache[value-intCacheMin]
+	}
+	return &Integer{Value: value}
+}
+
 type Float struct {
 	Value float64
 }

--- a/src/update/github.go
+++ b/src/update/github.go
@@ -1,0 +1,128 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	repoOwner = "javanhut"
+	repoName  = "TheCarrionLanguage"
+	apiBase   = "https://api.github.com"
+)
+
+type releaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
+type releaseInfo struct {
+	TagName     string         `json:"tag_name"`
+	Name        string         `json:"name"`
+	PublishedAt time.Time      `json:"published_at"`
+	HTMLURL     string         `json:"html_url"`
+	Prerelease  bool           `json:"prerelease"`
+	Draft       bool           `json:"draft"`
+	Assets      []releaseAsset `json:"assets"`
+}
+
+type commitInfo struct {
+	SHA    string `json:"sha"`
+	Commit struct {
+		Message   string `json:"message"`
+		Committer struct {
+			Date time.Time `json:"date"`
+			Name string    `json:"name"`
+		} `json:"committer"`
+	} `json:"commit"`
+	HTMLURL string `json:"html_url"`
+}
+
+// httpClient is the shared client used for GitHub API and asset downloads.
+// A generous timeout covers slow CI links but avoids hanging forever.
+var httpClient = &http.Client{Timeout: 5 * time.Minute}
+
+func fetchLatestRelease() (*releaseInfo, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", apiBase, repoOwner, repoName)
+	body, err := apiGet(url)
+	if err != nil {
+		return nil, err
+	}
+	var r releaseInfo
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("decode release: %w", err)
+	}
+	return &r, nil
+}
+
+func fetchLatestCommit(branch string) (*commitInfo, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/commits/%s", apiBase, repoOwner, repoName, branch)
+	body, err := apiGet(url)
+	if err != nil {
+		return nil, err
+	}
+	var c commitInfo
+	if err := json.Unmarshal(body, &c); err != nil {
+		return nil, fmt.Errorf("decode commit: %w", err)
+	}
+	return &c, nil
+}
+
+func apiGet(url string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "carrion-update")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read github response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github API returned %s: %s", resp.Status, truncate(string(body), 200))
+	}
+	return body, nil
+}
+
+// downloadTo streams a URL to dst, creating any parent directories.
+func downloadTo(url, dst string) error {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "carrion-update")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: %s", url, resp.Status)
+	}
+	f, err := createFile(dst)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	return nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/src/update/install.go
+++ b/src/update/install.go
@@ -1,0 +1,363 @@
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// readSourceVersion extracts the default `var Version = "x.y.z"` value from
+// the cloned source tree. Used so an experimental build reports the repo's
+// current semver, not the running binary's semver (main may be ahead).
+// Returns "" if the file is missing or unparseable — caller must supply a
+// fallback.
+func readSourceVersion(sourceDir string) string {
+	path := filepath.Join(sourceDir, "src", "version", "version.go")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	re := regexp.MustCompile(`var\s+Version\s*=\s*"([^"]+)"`)
+	m := re.FindSubmatch(data)
+	if len(m) < 2 {
+		return ""
+	}
+	return string(m[1])
+}
+
+// assetNameForHost returns the expected release asset filename for the host
+// OS/arch, matching the naming used by the Makefile targets.
+// Windows builds are shipped as .zip; Linux/macOS as .tar.gz.
+func assetNameForHost() (string, bool) {
+	switch runtime.GOOS {
+	case "linux":
+		return fmt.Sprintf("carrion_linux_%s.tar.gz", runtime.GOARCH), true
+	case "darwin":
+		return fmt.Sprintf("carrion_darwin_%s.tar.gz", runtime.GOARCH), true
+	case "windows":
+		return fmt.Sprintf("carrion_windows_%s.zip", runtime.GOARCH), true
+	default:
+		return "", false
+	}
+}
+
+func currentBinaryPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("locate current binary: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return exe, nil
+	}
+	return resolved, nil
+}
+
+// canWrite reports whether the calling user can replace the file at path.
+// We probe with O_WRONLY rather than checking mode bits because effective
+// permissions depend on ownership, ACLs, and mount options we can't read.
+func canWrite(path string) bool {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+// replaceBinary atomically swaps targetPath with the file at newPath,
+// preserving the target's mode bits so the replacement stays executable.
+// On Linux/macOS, renaming over a running binary is safe; on Windows, we move
+// the current binary aside and then rename the new one in.
+func replaceBinary(newPath, targetPath string) error {
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", targetPath, err)
+	}
+	mode := info.Mode().Perm()
+	if err := os.Chmod(newPath, mode); err != nil {
+		return fmt.Errorf("chmod new binary: %w", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		backup := targetPath + ".old"
+		_ = os.Remove(backup)
+		if err := os.Rename(targetPath, backup); err != nil {
+			return fmt.Errorf("move old binary aside: %w", err)
+		}
+		if err := os.Rename(newPath, targetPath); err != nil {
+			_ = os.Rename(backup, targetPath)
+			return fmt.Errorf("install new binary: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.Rename(newPath, targetPath); err != nil {
+		return fmt.Errorf("install new binary: %w", err)
+	}
+	return nil
+}
+
+// extractTarGz extracts a gzipped tar archive into destDir and returns the
+// paths of the Carrion-related binaries it wrote (carrion, sindri, mimir).
+func extractTarGz(archivePath, destDir string) (map[string]string, error) {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("gzip open: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	return extractStream(tr, destDir)
+}
+
+// extractZip handles the Windows release format.
+func extractZip(archivePath, destDir string) (map[string]string, error) {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	binaries := map[string]string{}
+	for _, f := range r.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		outPath, name := placeInto(destDir, f.Name)
+		if outPath == "" {
+			continue
+		}
+		src, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		dst, err := createFile(outPath)
+		if err != nil {
+			src.Close()
+			return nil, err
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			src.Close()
+			dst.Close()
+			return nil, err
+		}
+		src.Close()
+		dst.Close()
+		if name != "" {
+			binaries[name] = outPath
+		}
+	}
+	return binaries, nil
+}
+
+type tarReader interface {
+	Next() (*tar.Header, error)
+	io.Reader
+}
+
+func extractStream(tr tarReader, destDir string) (map[string]string, error) {
+	binaries := map[string]string{}
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if h.FileInfo().IsDir() {
+			continue
+		}
+		outPath, name := placeInto(destDir, h.Name)
+		if outPath == "" {
+			continue
+		}
+		dst, err := createFile(outPath)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := io.Copy(dst, tr); err != nil {
+			dst.Close()
+			return nil, err
+		}
+		dst.Close()
+		if name != "" {
+			binaries[name] = outPath
+		}
+	}
+	return binaries, nil
+}
+
+// placeInto maps an archive entry path to a destination path and reports the
+// logical binary name (carrion, sindri, mimir) if it's one we care about.
+// Returns ("", "") for entries to ignore.
+func placeInto(destDir, entryPath string) (string, string) {
+	base := filepath.Base(entryPath)
+	switch strings.TrimSuffix(base, ".exe") {
+	case "carrion":
+		return filepath.Join(destDir, base), "carrion"
+	case "sindri":
+		return filepath.Join(destDir, base), "sindri"
+	case "mimir":
+		return filepath.Join(destDir, base), "mimir"
+	}
+	return "", ""
+}
+
+func createFile(path string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+}
+
+// cloneAt fetches the repo into destDir and checks out the given ref.
+// Uses --depth=1 for speed; falls back to a full fetch if the ref isn't in the
+// shallow clone (rare — HEAD of main always is).
+func cloneAt(ref, destDir string) error {
+	if _, err := exec.LookPath("git"); err != nil {
+		return fmt.Errorf("git not found in PATH — experimental updates require git")
+	}
+	url := fmt.Sprintf("https://github.com/%s/%s.git", repoOwner, repoName)
+	cmd := exec.Command("git", "clone", "--depth", "50", url, destDir)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git clone: %w", err)
+	}
+	if ref == "" {
+		return nil
+	}
+	checkout := exec.Command("git", "-C", destDir, "checkout", ref)
+	checkout.Stdout = os.Stderr
+	checkout.Stderr = os.Stderr
+	if err := checkout.Run(); err != nil {
+		unshallow := exec.Command("git", "-C", destDir, "fetch", "--unshallow")
+		unshallow.Stdout = os.Stderr
+		unshallow.Stderr = os.Stderr
+		if uerr := unshallow.Run(); uerr != nil {
+			return fmt.Errorf("checkout %s: %w (unshallow also failed: %v)", ref, err, uerr)
+		}
+		retry := exec.Command("git", "-C", destDir, "checkout", ref)
+		retry.Stdout = os.Stderr
+		retry.Stderr = os.Stderr
+		if err := retry.Run(); err != nil {
+			return fmt.Errorf("checkout %s after unshallow: %w", ref, err)
+		}
+	}
+	return nil
+}
+
+// buildFromSource compiles carrion plus the sindri and mimir companion
+// binaries from sourceDir into outDir, baking the given version/commit/channel
+// into carrion via ldflags. Returns a map of binary-name → absolute path for
+// whatever built successfully. sindri and mimir are best-effort: if their
+// packages are missing from the tree (older commits), they're skipped with a
+// warning rather than failing the whole update.
+func buildFromSource(sourceDir, outDir, semver, commit, channel string) (map[string]string, error) {
+	if _, err := exec.LookPath("go"); err != nil {
+		return nil, fmt.Errorf("go toolchain not found in PATH — experimental updates require go 1.24+")
+	}
+	ldflags := fmt.Sprintf(
+		"-X github.com/javanhut/TheCarrionLanguage/src/version.Version=%s "+
+			"-X github.com/javanhut/TheCarrionLanguage/src/version.Commit=%s "+
+			"-X github.com/javanhut/TheCarrionLanguage/src/version.Channel=%s "+
+			"-X github.com/javanhut/TheCarrionLanguage/src/version.BuildDate=%s",
+		semver, commit, channel, time.Now().UTC().Format(time.RFC3339),
+	)
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	bins := map[string]string{}
+	// carrion is the primary binary — failure here aborts the update.
+	carrionOut := filepath.Join(outDir, binName("carrion"))
+	cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", carrionOut, "./src")
+	cmd.Dir = sourceDir
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("go build carrion: %w", err)
+	}
+	bins["carrion"] = carrionOut
+
+	// sindri and mimir are companions — skip with a warning if not present.
+	for _, companion := range []struct{ name, pkg string }{
+		{"sindri", "./cmd/sindri"},
+		{"mimir", "./cmd/mimir"},
+	} {
+		if _, err := os.Stat(filepath.Join(sourceDir, companion.pkg)); err != nil {
+			fmt.Fprintf(os.Stderr, "  (skipping %s — %s not in source tree)\n", companion.name, companion.pkg)
+			continue
+		}
+		out := filepath.Join(outDir, binName(companion.name))
+		c := exec.Command("go", "build", "-o", out, companion.pkg)
+		c.Dir = sourceDir
+		c.Stdout = os.Stderr
+		c.Stderr = os.Stderr
+		if err := c.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "  (warning: %s build failed: %v)\n", companion.name, err)
+			continue
+		}
+		bins[companion.name] = out
+	}
+	return bins, nil
+}
+
+// binName returns the platform-appropriate executable filename.
+func binName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
+// installBundle swaps each staged binary into destDir, replacing any existing
+// carrion/sindri/mimir at that path. Binaries whose counterparts don't exist
+// in destDir are skipped — the user may have only installed carrion, and we
+// don't want to silently create new binaries they didn't ask for.
+// Returns the list of binary names actually installed.
+func installBundle(bins map[string]string, destDir string) ([]string, error) {
+	// Install carrion last: if a companion fails, we haven't yet replaced the
+	// main binary, so the user's install is still coherent.
+	order := []string{"sindri", "mimir", "carrion"}
+	var installed []string
+	for _, name := range order {
+		src, ok := bins[name]
+		if !ok {
+			continue
+		}
+		dest := filepath.Join(destDir, binName(name))
+		if _, err := os.Stat(dest); err != nil {
+			if os.IsNotExist(err) {
+				if name == "carrion" {
+					// carrion MUST exist — we found it via os.Executable().
+					return installed, fmt.Errorf("carrion binary missing from %s (unexpected)", destDir)
+				}
+				fmt.Fprintf(os.Stderr, "  (skipping %s — not previously installed at %s)\n", name, destDir)
+				continue
+			}
+			return installed, fmt.Errorf("stat %s: %w", dest, err)
+		}
+		if err := replaceBinary(src, dest); err != nil {
+			return installed, fmt.Errorf("install %s: %w", name, err)
+		}
+		installed = append(installed, name)
+	}
+	return installed, nil
+}
+

--- a/src/update/semver.go
+++ b/src/update/semver.go
@@ -1,0 +1,98 @@
+package update
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// semver is a minimal major.minor.patch representation. Carrion releases don't
+// use build metadata or pre-release identifiers beyond an optional commit
+// suffix (which we strip before comparison), so a richer parser isn't needed.
+type semver struct {
+	Major, Minor, Patch int
+}
+
+// parseSemver accepts inputs like "v0.1.9", "0.1.9", "v0.1.9-a1b2c3d", and
+// returns the semver with any pre-release suffix discarded.
+func parseSemver(s string) (semver, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return semver{}, fmt.Errorf("not a major.minor.patch version: %q", s)
+	}
+	out := semver{}
+	vals := []*int{&out.Major, &out.Minor, &out.Patch}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return semver{}, fmt.Errorf("invalid number in version %q: %s", s, p)
+		}
+		*vals[i] = n
+	}
+	return out, nil
+}
+
+// compare returns -1, 0, 1 like strings.Compare.
+func (a semver) compare(b semver) int {
+	if a.Major != b.Major {
+		if a.Major < b.Major {
+			return -1
+		}
+		return 1
+	}
+	if a.Minor != b.Minor {
+		if a.Minor < b.Minor {
+			return -1
+		}
+		return 1
+	}
+	if a.Patch != b.Patch {
+		if a.Patch < b.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// bumpKind classifies the difference between two versions so the updater can
+// tell the user "this is a major update" vs "this is a patch".
+type bumpKind int
+
+const (
+	bumpNone bumpKind = iota
+	bumpPatch
+	bumpMinor
+	bumpMajor
+)
+
+func (b bumpKind) String() string {
+	switch b {
+	case bumpPatch:
+		return "patch"
+	case bumpMinor:
+		return "minor"
+	case bumpMajor:
+		return "major"
+	default:
+		return "none"
+	}
+}
+
+func classifyBump(from, to semver) bumpKind {
+	switch {
+	case to.Major > from.Major:
+		return bumpMajor
+	case to.Minor > from.Minor:
+		return bumpMinor
+	case to.Patch > from.Patch:
+		return bumpPatch
+	default:
+		return bumpNone
+	}
+}

--- a/src/update/semver_test.go
+++ b/src/update/semver_test.go
@@ -1,0 +1,75 @@
+package update
+
+import "testing"
+
+func TestParseSemver(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    semver
+		wantErr bool
+	}{
+		{"0.1.9", semver{0, 1, 9}, false},
+		{"v0.1.9", semver{0, 1, 9}, false},
+		{" v1.2.3 ", semver{1, 2, 3}, false},
+		{"v0.1.9-a1b2c3d", semver{0, 1, 9}, false},
+		{"v1.0.0+build.42", semver{1, 0, 0}, false},
+		{"v10.20.30", semver{10, 20, 30}, false},
+		{"", semver{}, true},
+		{"v1.2", semver{}, true},
+		{"v1.2.x", semver{}, true},
+		{"not-a-version", semver{}, true},
+	}
+	for _, tc := range cases {
+		got, err := parseSemver(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseSemver(%q): want error, got %+v", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSemver(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseSemver(%q) = %+v, want %+v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSemverCompare(t *testing.T) {
+	cases := []struct {
+		a, b semver
+		want int
+	}{
+		{semver{0, 1, 9}, semver{0, 1, 9}, 0},
+		{semver{0, 1, 9}, semver{0, 1, 10}, -1},
+		{semver{0, 1, 10}, semver{0, 1, 9}, 1},
+		{semver{0, 2, 0}, semver{0, 1, 99}, 1},
+		{semver{1, 0, 0}, semver{0, 99, 99}, 1},
+		{semver{0, 1, 9}, semver{0, 2, 0}, -1},
+	}
+	for _, tc := range cases {
+		if got := tc.a.compare(tc.b); got != tc.want {
+			t.Errorf("%+v.compare(%+v) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestClassifyBump(t *testing.T) {
+	cases := []struct {
+		from, to semver
+		want     bumpKind
+	}{
+		{semver{0, 1, 9}, semver{0, 1, 9}, bumpNone},
+		{semver{0, 1, 9}, semver{0, 1, 10}, bumpPatch},
+		{semver{0, 1, 9}, semver{0, 2, 0}, bumpMinor},
+		{semver{0, 1, 9}, semver{1, 0, 0}, bumpMajor},
+		{semver{0, 1, 9}, semver{2, 0, 0}, bumpMajor},
+	}
+	for _, tc := range cases {
+		if got := classifyBump(tc.from, tc.to); got != tc.want {
+			t.Errorf("classifyBump(%+v, %+v) = %v, want %v", tc.from, tc.to, got, tc.want)
+		}
+	}
+}

--- a/src/update/update.go
+++ b/src/update/update.go
@@ -1,0 +1,317 @@
+// Package update implements the `carrion update` subcommand. It fetches the
+// latest release (or latest main-branch commit with --experimental) from
+// GitHub, compares against the running binary's baked-in version metadata,
+// prompts the user, and swaps the on-disk binary in place.
+package update
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/javanhut/TheCarrionLanguage/src/version"
+)
+
+// Run parses update-subcommand args and executes the update flow. It returns
+// an error (suitable for printing) on any failure; the caller handles exit.
+// args is everything after the "update" keyword, e.g. ["--experimental"].
+func Run(args []string) error {
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: carrion update [flags]")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Updates the carrion binary in place.")
+		fmt.Fprintln(os.Stderr, "Default channel is stable releases (patch/minor/major).")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Flags:")
+		fs.PrintDefaults()
+	}
+	experimental := fs.Bool("experimental", false, "Track latest commit on main (builds from source, requires go)")
+	check := fs.Bool("check", false, "Check for updates and print the result; do not install")
+	yes := fs.Bool("yes", false, "Skip confirmation prompt")
+	yesShort := fs.Bool("y", false, "Skip confirmation prompt (short form)")
+	verbose := fs.Bool("verbose", false, "Print extra diagnostic information")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	opts := options{
+		experimental: *experimental,
+		check:        *check,
+		yes:          *yes || *yesShort,
+		verbose:      *verbose,
+	}
+
+	if opts.experimental {
+		return runExperimental(opts)
+	}
+	return runStable(opts)
+}
+
+type options struct {
+	experimental bool
+	check        bool
+	yes          bool
+	verbose      bool
+}
+
+// checkAvailable tracks whether `--check` mode found an available update. The
+// caller exposes this via CheckExitCode() so `carrion update --check` can
+// distinguish "up to date" (exit 0) from "update available" (exit 1) in CI
+// scripts.
+var checkAvailable bool
+
+func setCheckAvailable() { checkAvailable = true }
+
+// CheckExitCode returns the exit code the main binary should use after Run()
+// returns nil. Non-zero only when --check was used and an update was found.
+func CheckExitCode() int {
+	if checkAvailable {
+		return 1
+	}
+	return 0
+}
+
+// runStable resolves the latest GitHub release, compares semver against the
+// current binary, and (if newer) downloads the release asset or falls back to
+// a source build at the release tag.
+func runStable(opts options) error {
+	fmt.Fprintf(os.Stderr, "Current version: %s\n", version.Full())
+
+	rel, err := fetchLatestRelease()
+	if err != nil {
+		return fmt.Errorf("fetch latest release: %w", err)
+	}
+	if rel.Draft {
+		return fmt.Errorf("latest release is a draft; nothing to update to")
+	}
+
+	latest, err := parseSemver(rel.TagName)
+	if err != nil {
+		return fmt.Errorf("parse release tag %q: %w", rel.TagName, err)
+	}
+	current, err := parseSemver(version.Short())
+	if err != nil {
+		return fmt.Errorf("parse current version %q: %w", version.Short(), err)
+	}
+
+	cmp := current.compare(latest)
+	var prompt string
+	switch {
+	case cmp == 0 && !version.IsExperimental():
+		fmt.Fprintln(os.Stderr, "You are already on the latest stable release.")
+		return nil
+	case cmp == 0 && version.IsExperimental():
+		fmt.Fprintf(os.Stderr,
+			"You are on %s, an experimental build at the same semver as stable %s.\n",
+			version.Full(), rel.TagName)
+		if opts.check {
+			setCheckAvailable()
+			return nil
+		}
+		prompt = fmt.Sprintf("Pin back to the clean stable release %s?", rel.TagName)
+	case cmp > 0:
+		fmt.Fprintf(os.Stderr,
+			"Your version (%s) is newer than the latest stable release (%s).\n"+
+				"Nothing to update.\n", version.Full(), rel.TagName)
+		return nil
+	default:
+		bump := classifyBump(current, latest)
+		fmt.Fprintf(os.Stderr, "A new %s release is available: %s (published %s)\n",
+			bump, rel.TagName, rel.PublishedAt.Format("2006-01-02"))
+		if rel.HTMLURL != "" {
+			fmt.Fprintf(os.Stderr, "  %s\n", rel.HTMLURL)
+		}
+		if opts.check {
+			setCheckAvailable()
+			return nil
+		}
+		prompt = fmt.Sprintf("Update to %s now?", rel.TagName)
+	}
+
+	if !opts.yes {
+		ok, err := confirm(prompt)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Aborted.")
+			return nil
+		}
+	}
+
+	binPath, err := currentBinaryPath()
+	if err != nil {
+		return err
+	}
+	if !canWrite(binPath) {
+		return fmt.Errorf("cannot write to %s — re-run with sudo or as the install owner", binPath)
+	}
+
+	tmp, err := os.MkdirTemp("", "carrion-update-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+
+	bins, err := acquireReleaseBundle(rel, tmp, latest, opts)
+	if err != nil {
+		return err
+	}
+
+	installed, err := installBundle(bins, filepath.Dir(binPath))
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Updated to %s (%s) at %s\n", rel.TagName, strings.Join(installed, ", "), filepath.Dir(binPath))
+	return nil
+}
+
+// runExperimental tracks main-branch HEAD: fetch the latest commit SHA, short-
+// circuit if already on that commit, otherwise clone the source, build with
+// version/commit baked in, and install.
+func runExperimental(opts options) error {
+	fmt.Fprintf(os.Stderr, "Current version: %s\n", version.Full())
+
+	commit, err := fetchLatestCommit("main")
+	if err != nil {
+		return fmt.Errorf("fetch main HEAD: %w", err)
+	}
+	latestShort := commit.SHA
+	if len(latestShort) > 7 {
+		latestShort = latestShort[:7]
+	}
+
+	if version.CommitShort() == latestShort {
+		fmt.Fprintf(os.Stderr, "You are already on main@%s.\n", latestShort)
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "New commit on main: %s\n", latestShort)
+	if subj := strings.SplitN(commit.Commit.Message, "\n", 2)[0]; subj != "" {
+		fmt.Fprintf(os.Stderr, "  %s\n", subj)
+	}
+	if commit.HTMLURL != "" {
+		fmt.Fprintf(os.Stderr, "  %s\n", commit.HTMLURL)
+	}
+
+	if opts.check {
+		setCheckAvailable()
+		return nil
+	}
+
+	if !opts.yes {
+		ok, err := confirm(fmt.Sprintf("Update to v%s-%s now?", version.Short(), latestShort))
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(os.Stderr, "Aborted.")
+			return nil
+		}
+	}
+
+	binPath, err := currentBinaryPath()
+	if err != nil {
+		return err
+	}
+	if !canWrite(binPath) {
+		return fmt.Errorf("cannot write to %s — re-run with sudo or as the install owner", binPath)
+	}
+
+	tmp, err := os.MkdirTemp("", "carrion-update-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+
+	srcDir := filepath.Join(tmp, "src")
+	outDir := filepath.Join(tmp, "built")
+	fmt.Fprintln(os.Stderr, "Cloning source…")
+	if err := cloneAt(commit.SHA, srcDir); err != nil {
+		return err
+	}
+	semver := readSourceVersion(srcDir)
+	if semver == "" {
+		semver = version.Short()
+	}
+	fmt.Fprintln(os.Stderr, "Building…")
+	bins, err := buildFromSource(srcDir, outDir, semver, commit.SHA, "experimental")
+	if err != nil {
+		return err
+	}
+	installed, err := installBundle(bins, filepath.Dir(binPath))
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Updated to v%s-%s (%s) at %s\n", semver, latestShort, strings.Join(installed, ", "), filepath.Dir(binPath))
+	return nil
+}
+
+// acquireReleaseBundle picks the right strategy for obtaining the stable-
+// release binary set (carrion + sindri + mimir): prefer a prebuilt asset
+// matching the host OS/arch, fall back to a source build at the release tag.
+func acquireReleaseBundle(rel *releaseInfo, tmp string, latest semver, opts options) (map[string]string, error) {
+	assetName, supported := assetNameForHost()
+	if supported {
+		for _, a := range rel.Assets {
+			if a.Name == assetName {
+				archivePath := filepath.Join(tmp, a.Name)
+				fmt.Fprintf(os.Stderr, "Downloading %s…\n", a.Name)
+				if err := downloadTo(a.BrowserDownloadURL, archivePath); err != nil {
+					return nil, err
+				}
+				extractDir := filepath.Join(tmp, "extracted")
+				bins, err := extractAsset(archivePath, extractDir)
+				if err != nil {
+					return nil, err
+				}
+				if bins["carrion"] == "" {
+					return nil, fmt.Errorf("release asset %s did not contain a carrion binary", a.Name)
+				}
+				return bins, nil
+			}
+		}
+		if opts.verbose {
+			fmt.Fprintf(os.Stderr, "No asset named %s in release %s — falling back to source build.\n",
+				assetName, rel.TagName)
+		}
+	} else if opts.verbose {
+		fmt.Fprintf(os.Stderr, "Host OS %q has no prebuilt asset convention — falling back to source build.\n",
+			runtime.GOOS)
+	}
+
+	srcDir := filepath.Join(tmp, "src")
+	outDir := filepath.Join(tmp, "built")
+	fmt.Fprintln(os.Stderr, "Cloning source…")
+	if err := cloneAt(rel.TagName, srcDir); err != nil {
+		return nil, err
+	}
+	fmt.Fprintln(os.Stderr, "Building…")
+	return buildFromSource(srcDir, outDir, fmt.Sprintf("%d.%d.%d", latest.Major, latest.Minor, latest.Patch), "", "release")
+}
+
+func extractAsset(archivePath, destDir string) (map[string]string, error) {
+	if strings.HasSuffix(archivePath, ".zip") {
+		return extractZip(archivePath, destDir)
+	}
+	return extractTarGz(archivePath, destDir)
+}
+
+func confirm(prompt string) (bool, error) {
+	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
+	r := bufio.NewReader(os.Stdin)
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes", nil
+}
+

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -1,0 +1,61 @@
+// Package version exposes the build-time version metadata for the Carrion
+// language binary. All fields are intended to be overridden at build time via
+// `go build -ldflags "-X github.com/javanhut/TheCarrionLanguage/src/version.Version=..."`
+// so the running binary can report exactly what source it was built from.
+package version
+
+// Version is the base Carrion semver: major.minor.patch (no leading "v", no
+// pre-release suffix). The release workflow rewrites this value on tag push
+// so bumping is automatic — do not edit by hand unless you're doing something
+// unusual. Local `go build` without ldflags picks up this default.
+var Version = "0.1.9"
+
+// Commit is the short git SHA the binary was built from. Empty string means
+// "tagged release" — omit the suffix when formatting the version. Any non-empty
+// value means the binary was built from an untagged commit (experimental).
+var Commit = ""
+
+// Channel identifies the release stream:
+//   - "release"      — built from a tagged release
+//   - "experimental" — built from a main-branch commit via `carrion update --experimental`
+//   - "dev"          — local developer build (default)
+var Channel = "dev"
+
+// BuildDate is the UTC build timestamp in RFC3339 format. Optional; empty when
+// not injected.
+var BuildDate = ""
+
+// Full returns the user-facing version string.
+//
+//	v0.1.9          — tagged release (Commit empty)
+//	v0.1.9-a1b2c3d  — experimental build (Commit set; trimmed to 7 chars)
+func Full() string {
+	if Commit == "" {
+		return "v" + Version
+	}
+	return "v" + Version + "-" + shortCommit()
+}
+
+// Short returns the raw semver without the leading "v" and without the commit
+// suffix. Useful for semver comparisons.
+func Short() string {
+	return Version
+}
+
+// CommitShort returns the 7-character abbreviated commit hash, or "" if Commit
+// was not injected.
+func CommitShort() string {
+	return shortCommit()
+}
+
+// IsExperimental reports whether this binary was built from a non-tagged commit.
+func IsExperimental() bool {
+	return Commit != ""
+}
+
+func shortCommit() string {
+	if len(Commit) <= 7 {
+		return Commit
+	}
+	return Commit[:7]
+}


### PR DESCRIPTION

  Summary

  Three pieces of work bundled into one PR targeting 0.1.10:

  1. Evaluator performance. Small-integer cache, deferred primitive wrapping, native-Go dispatch for 15 Array methods, infix fast path for raw primitives, and removed defer from the Eval hot
  loop.
  2. carrion update subcommand. Self-updating binary with stable and --experimental channels, plus a src/version package holding build-time-injectable version metadata.
  3. Auto-versioned docs + release workflow. cmd/versionsync keeps every version reference in the docs in sync with src/version/version.go. The release workflow rewrites version.go, syncs
  docs, commits back to main, and cuts the GitHub release — all from a single git tag v0.1.10 && git push --tags.

  Version is currently 0.1.9 in the tree. Tagging v0.1.10 is what actually cuts the release; the changelog sits under ## Unreleased until then.

  Why

  - Tight arithmetic loops in Carrion were spending most of their time allocating *object.Integer and wrapping primitives into grimoire instances that were never used as instances. Easy wins
  on the profiler.
  - Users had no way to update Carrion without re-running make install from a fresh clone.
  - Release docs drifted from the actual version (README stuck at 0.1.9, Complete-Reference at 0.1.7, etc.). Needed a single source of truth and CI enforcement.

  Performance

  Measured on Intel i5-10500H, Linux, Go 1.24, count=3 to smooth variance. Baseline is f5b487a (pre-improvements) with the new benchmark file copied onto it.

  ┌────────────────────┬─────────────────┬──────────────────┬────────┬──────────┐
  │     Benchmark      │     Before      │      After       │ Δ time │ Δ allocs │
  ├────────────────────┼─────────────────┼──────────────────┼────────┼──────────┤
  │ IntegerLoop        │ 7.13 ms / 40 K  │ 2.21 ms / 19.8 K │ 3.2×   │ −50.6%   │
  ├────────────────────┼─────────────────┼──────────────────┼────────┼──────────┤
  │ Arithmetic         │ 8.10 ms / 50 K  │ 2.62 ms / 24.6 K │ 3.1×   │ −50.8%   │
  ├────────────────────┼─────────────────┼──────────────────┼────────┼──────────┤
  │ Fibonacci (fib 20) │ 45.4 ms / 263 K │ 17.5 ms / 164 K  │ 2.6×   │ −37.5%   │
  ├────────────────────┼─────────────────┼──────────────────┼────────┼──────────┤
  │ ArrayBuild         │ 14.9 ms / 9.0 K │ 2.93 ms / 5.75 K │ ~5×    │ −36.1%   │
  ├────────────────────┼─────────────────┼──────────────────┼────────┼──────────┤
  │ StringConcat       │ 1.42 ms / 8.0 K │ 0.58 ms / 4.75 K │ 2.4×   │ −40.7%   │
  └────────────────────┴─────────────────┴──────────────────┴────────┴──────────┘

  Reproduce with make bench.

  User-visible changes

  carrion --version now reports a structured semver:
  - v0.1.10 on a tagged release.
  - v0.1.10-a1b2c3d on an experimental build (commit SHA baked in via ldflags).

  New subcommand:
  carrion update                # Stable — downloads prebuilt asset or source-builds the tag
  carrion update --experimental # Track main HEAD; clone + build
  carrion update --check        # Exit 0 if current, 1 if update available, 2 on error
  carrion update -y             # Skip confirmation prompt

  Updates replace all three installed binaries (carrion, sindri, mimir) atomically. Writes permission-protected install dirs surface a clear "re-run with sudo" message instead of failing
  mid-install.

  Language behavior is unchanged. Deferred primitive wrapping still produces the same results for "hello".upper() and [1, 2, 3].length(); native Array sort/reverse return Instance-wrapped
  results matching the stdlib.

  Release infrastructure

  Single source of truth: src/version/version.go. Bumping it (or letting the release workflow do it from a tag) propagates automatically to every tracked doc via cmd/versionsync.

  Makefile additions:
  - make bench, make test
  - make sync-version — rewrite docs from version.go
  - make version-check — CI-friendly drift check (exits 1 on mismatch)
  - make build-mac, make build-linux-arm64, make build-release — full matrix
  - CARRION_LDFLAGS injected into build-linux, build-linux-arm64, build-windows, build-mac-*

  New CI workflow (.github/workflows/ci.yml): on push to main and every PR, runs make version-check, make test, a build smoke test, and asserts carrion --version agrees with version.go.

  Rewritten release workflow (.github/workflows/release.yml): triggered by pushing a v* tag. Extracts the semver, rewrites version.go, runs sync-version, commits back to main, runs tests,
  builds the full six-artifact matrix, and creates the GitHub release. No manual doc or version.go edits needed — the tag push is the release.

  New files

  src/version/version.go                — Version metadata (ldflags-injected)
  src/update/{update,github,install,semver,semver_test}.go — `carrion update`
  src/evaluator/evaluator_bench_test.go — Performance benchmarks
  cmd/versionsync/main.go               — Doc version sync tool
  .github/workflows/ci.yml              — PR and main-branch CI

  Rewritten: .github/workflows/release.yml.

  Test plan

  - make test passes (covers new semver tests + existing suites)
  - make bench runs and shows improvements vs main
  - make version-check reports "in sync with version 0.1.9"
  - go build ./src && ./carrion --version reports v0.1.9
  - ./carrion update --check reports "already on the latest stable release" (exits 0)
  - ./carrion update --experimental --check fetches main HEAD and exits 1 (update available) or 0 (already on it)
  - Existing .crl scripts in src/examples/ still run without errors
  - CI workflow runs green on this PR